### PR TITLE
Update incominglistener.go

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -303,23 +303,23 @@ func newResult(deviceObject models.DeviceObject, ro models.ResourceOperation, re
 	case "String":
 		result = sdkModel.NewStringValue(&ro, resTime, reading.(string))
 	case "Uint8":
-		result, err = sdkModel.NewUint8Value(&ro, resTime, reading.(uint8))
+		result, err = sdkModel.NewUint8Value(&ro, resTime, uint8(reading.(float64)))
 	case "Uint16":
-		result, err = sdkModel.NewUint16Value(&ro, resTime, reading.(uint16))
+		result, err = sdkModel.NewUint16Value(&ro, resTime, uint16(reading.(float64)))
 	case "Uint32":
-		result, err = sdkModel.NewUint32Value(&ro, resTime, reading.(uint32))
+		result, err = sdkModel.NewUint32Value(&ro, resTime, uint32(reading.(float64)))
 	case "Uint64":
-		result, err = sdkModel.NewUint64Value(&ro, resTime, reading.(uint64))
+		result, err = sdkModel.NewUint64Value(&ro, resTime, uint64(reading.(float64)))
 	case "Int8":
-		result, err = sdkModel.NewInt8Value(&ro, resTime, reading.(int8))
+		result, err = sdkModel.NewInt8Value(&ro, resTime, int8(reading.(float64)))
 	case "Int16":
-		result, err = sdkModel.NewInt16Value(&ro, resTime, reading.(int16))
+		result, err = sdkModel.NewInt16Value(&ro, resTime, int16(reading.(float64)))
 	case "Int32":
-		result, err = sdkModel.NewInt32Value(&ro, resTime, reading.(int32))
+		result, err = sdkModel.NewInt32Value(&ro, resTime, int32(reading.(float64)))
 	case "Int64":
-		result, err = sdkModel.NewInt64Value(&ro, resTime, reading.(int64))
+		result, err = sdkModel.NewInt64Value(&ro, resTime, int64(reading.(float64)))
 	case "Float32":
-		result, err = sdkModel.NewFloat32Value(&ro, resTime, reading.(float32))
+		result, err = sdkModel.NewFloat32Value(&ro, resTime, float32(reading.(float64)))
 	case "Float64":
 		result, err = sdkModel.NewFloat64Value(&ro, resTime, reading.(float64))
 	default:

--- a/internal/driver/incominglistener.go
+++ b/internal/driver/incominglistener.go
@@ -55,7 +55,12 @@ func startIncomingListening() error {
 func onIncomingDataReceived(client mqtt.Client, message mqtt.Message) {
 	var response map[string]interface{}
 	json.Unmarshal(message.Payload(), &response)
-
+	// add check the data format by Geoffrey
+	if response == nil || response["name"] == nil || response["cmd"] == nil {
+		driver.Logger.Warn(fmt.Sprintf("[Incoming listener] Incoming reading ignored. Data Format Error, couldn't be converted to Map[String]interface{}  : topic=%v payload=%v", message.Topic(), string(message.Payload())))
+		return
+	}
+	
 	deviceName := response["name"].(string)
 	cmd := response["cmd"].(string)
 	reading := response[cmd]


### PR DESCRIPTION
#9 
Action： add check the data format of Payload by Geoffrey

Reason：
      If the Payload is  `"testmest"` or `{"run":"100"}···, it will make the `device-mqtt-go` service exit by the panic `panic: interface conversion: interface {} is nil, not string`. Because these non-standard formats cannot be converted to `map[string]interface{}`. Even though the Payload could be converted to `map[string]interface{}`, it must hava map["name"] and map["cmd"]. If not, the  the `device-mqtt-go` exit by the panic `panic: interface conversion: interface {} is nil, not string`. 
     As a DeviceService, the wrong data type can be left unprocessed, but should not cause the service to be unavailable.
      Therefore, we should verify the data format of Payload to prevent the `device-mqtt-go` from exiting abnormally due to data format problems. In addition, the availability of the `device-mqtt-go` is guaranteed. Maybe the way I deal with is not elegant enough, but I hope to attract attention to this kind of problem.


By Geoffrey