### PR TITLE
Remove RO 'property=value' from example device profile

### DIFF
--- a/cmd/res/example/mqtt.test.device.profile.yml
+++ b/cmd/res/example/mqtt.test.device.profile.yml
@@ -40,17 +40,17 @@ deviceCommands:
 -
   name: testrandnum
   get:
-  - { index: "1", operation: "get", object: "randnum", parameter: "randnum", property: "value" }
+  - { index: "1", operation: "get", object: "randnum", parameter: "randnum" }
 -
   name: testping
   get:
-  - { index: "1", operation: "get", object: "ping", parameter: "ping", property: "value" }
+  - { index: "1", operation: "get", object: "ping", parameter: "ping" }
 -
   name: testmessage
   get:
-  - { index: "1", operation: "get", object: "message", parameter: "message", property: "value" }
+  - { index: "1", operation: "get", object: "message", parameter: "message" }
   set:
-  - { index: "1", operation: "set", object: "message", parameter: "message", property: "value" }
+  - { index: "1", operation: "set", object: "message", parameter: "message" }
 
 coreCommands:
 -


### PR DESCRIPTION
Remove RO 'property=value' from example device profile, because this attribute was removed from the model.
Fix #45 