### PR TITLE
Update the version of device-sdk-go to v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/edgexfoundry/device-mqtt-go
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/device-sdk-go v0.0.0-20190606081126-e01baf7ec020
+	github.com/edgexfoundry/device-sdk-go v1.0.0
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.0
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/google/uuid v1.1.1 // indirect


### PR DESCRIPTION
The device-sdk-go is tagging the release v1.0.0, and all Device Services should use this dependency.
fix #73

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>