### PR TITLE
Specify consul address in registry arg in snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,7 +27,9 @@ epoch: 1
 apps:
   device-mqtt:
     adapter: none
-    command: bin/device-mqtt -confdir $SNAP_DATA/config/device-mqtt -profile res --registry
+    command: bin/device-mqtt -confdir $SNAP_DATA/config/device-mqtt -profile res --registry $CONSUL_ADDR
+    environment:
+      CONSUL_ADDR: "consul://localhost:8500"
     daemon: simple
     plugs: [network, network-bind]
 


### PR DESCRIPTION
As per edgexfoundry/device-sdk-go#274, the
registry arg for device services now needs a value, so use the default
value of consul from the edgexfoundry snap.

Fixes #75 