### PR TITLE
Install the example config file + device profile in the snap

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -19,6 +19,12 @@ if [ ! -f "$SNAP_DATA/config/device-mqtt/res/configuration.toml" ]; then
         "$SNAP_DATA/config/device-mqtt/res/configuration.toml"
 fi
 
+# also copy the device profile into $SNAP_DATA
+if [ ! -f "$SNAP_DATA/config/device-mqtt/res/mqtt.test.device.profile.yml" ]; then
+    cp "$SNAP/config/device-mqtt/res/mqtt.test.device.profile.yml" \
+        "$SNAP_DATA/config/device-mqtt/res/mqtt.test.device.profile.yml"
+fi
+
 # disable device-mqtt initially because it specific requires configuration 
 # with a device profile that will be specific to each installation
 snapctl stop --disable "$SNAP_NAME.device-mqtt"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -82,10 +82,13 @@ parts:
       # Override 'LogFile' and 'LoggingRemoteURL'
       install -d "$SNAPCRAFT_PART_INSTALL/config/device-mqtt/res/"
 
-      cat "./cmd/res/configuration.toml" | \
+      cat "./cmd/res/example/configuration.toml" | \
         sed -e s:\"./device-mqtt.log\":\'\$SNAP_COMMON/device-mqtt.log\': \
-          -e s:'ProfilesDir = \"./res\"':'ProfilesDir = \"\$SNAP_DATA/config/device-mqtt/res\"': > \
+          -e s:'ProfilesDir = \"./res/example\"':'ProfilesDir = \"\$SNAP_DATA/config/device-mqtt/res\"': > \
         "$SNAPCRAFT_PART_INSTALL/config/device-mqtt/res/configuration.toml"
+
+      install -DT "./cmd/res/example/mqtt.test.device.profile.yml" \
+        "$SNAPCRAFT_PART_INSTALL/config/device-mqtt/res/mqtt.test.device.profile.yml"
 
       install -DT "./cmd/Attribution.txt" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-mqtt/Attribution.txt"


### PR DESCRIPTION
* Process the ProfilesDir properly so it's in $SNAP_DATA
* Copy the device profile in the install hook so it's available when the service starts running and is imported by default

Fixes #83 for master/fuji