### PR TITLE
Remove AutoEvents from default example config, create new config for AutoEvents

### DIFF
--- a/cmd/res/example/configuration-autoevents.toml
+++ b/cmd/res/example/configuration-autoevents.toml
@@ -69,6 +69,10 @@ LogLevel = "DEBUG"
        User = "admin"
        Password = "public"
        Topic = "CommandTopic"
+  [[DeviceList.AutoEvents]]
+    Frequency = "20s"
+    OnChange = false
+    Resource = "testrandfloat32"
 
 # Driver configs
 [Driver]

--- a/cmd/res/example/configuration.toml
+++ b/cmd/res/example/configuration.toml
@@ -56,7 +56,7 @@ LogLevel = "DEBUG"
 
 # Pre-define Devices
 [[DeviceList]]
-  Name = "MQTT test device"
+  Name = "MQTT-test-device"
   Profile = "Test.Device.MQTT.Profile"
   Description = "MQTT device is created for test purpose"
   Labels = [ "MQTT", "test"]


### PR DESCRIPTION
* Remove AutoEvents from the default configuration.toml in examples/
* Add new configuration-autoevents.toml for showing how AutoEvents works with the device service
* Rename the default device to `MQTT-test-device` w/o spaces so that it doesn't trigger awkward bugs with having spaces in URL request paths and parameters.

Fixes #87 