### PR TITLE
Update SDK version to v1.1.0 for fuji branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/edgexfoundry/device-mqtt-go
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/device-sdk-go v0.0.0-20191023171807-49a95f741ef7
+	github.com/edgexfoundry/device-sdk-go v1.1.0
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.31
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/gorilla/mux v1.7.0 // indirect


### PR DESCRIPTION
Fix #116 
update device-sdk-go to v1.1.0