### PR TITLE
Fuji: Add license/copyright labels to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,7 @@ EXPOSE $APP_PORT
 
 COPY --from=builder /go/src/github.com/edgexfoundry/device-mqtt-go/cmd /
 
+LABEL license='SPDX-License-Identifier: Apache-2.0' \
+      copyright='Copyright (c) 2019: IoTech Ltd'
+
 ENTRYPOINT ["/device-mqtt","--profile=docker","--confdir=/res","--registry=consul://edgex-core-consul:8500"]


### PR DESCRIPTION
Add license/copyright labels to the docker container
Fix #127 