### PR TITLE
Fix doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Overview
 MQTT Micro Service - device service for connecting a MQTT topic to EdgeX acting like a device/sensor feed.
 ## Usage
-Users can refer to [the document](https://docs.edgexfoundry.org/Ch-ExamplesAddingMQTTDevice.html) to learn how to use this device service.
+Users can refer to [the document](https://docs.edgexfoundry.org/1.2/examples/Ch-ExamplesAddingMQTTDevice) to learn how to use this device service.
 
 ## Community
 - Chat: https://edgexfoundry.slack.com


### PR DESCRIPTION
Fix #136 
Change the doc link to https://docs.edgexfoundry.org/1.2/examples/Ch-ExamplesAddingMQTTDevice/