### PR TITLE
snap: add env override for ProfilesDir

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,8 @@ apps:
     command: bin/device-mqtt -confdir $SNAP_DATA/config/device-mqtt -profile res --registry $CONSUL_ADDR
     environment:
       CONSUL_ADDR: "consul://localhost:8500"
+      DEVICE_PROFILESDIR: $SNAP_DATA/config/device-mqtt/res
+      WRITABLE_LOGLEVEL: 'INFO'
     daemon: simple
     plugs: [network, network-bind]
 
@@ -78,14 +80,8 @@ parts:
 
       install -DT "./cmd/device-mqtt" "$SNAPCRAFT_PART_INSTALL/bin/device-mqtt"
 
-      # FIXME: settings can't be overridden from the cmd-line!
-      # Override 'LogFile' and 'LoggingRemoteURL'
-      install -d "$SNAPCRAFT_PART_INSTALL/config/device-mqtt/res/"
-
-      cat "./cmd/res/example/configuration.toml" | \
-        sed -e s:\"./device-mqtt.log\":\'\$SNAP_COMMON/device-mqtt.log\': \
-          -e s:'ProfilesDir = \"./res/example\"':'ProfilesDir = \"\$SNAP_DATA/config/device-mqtt/res\"': > \
-        "$SNAPCRAFT_PART_INSTALL/config/device-mqtt/res/configuration.toml"
+      # cp configuration.toml from example, as it includes a pre-defined device
+      install -DT "./cmd/res/example/configuration.toml" "$SNAPCRAFT_PART_INSTALL/config/device-mqtt/res/configuration.toml"
 
       install -DT "./cmd/res/example/mqtt.test.device.profile.yml" \
         "$SNAPCRAFT_PART_INSTALL/config/device-mqtt/res/mqtt.test.device.profile.yml"


### PR DESCRIPTION
This change removes the build-time edit of the `configuration.toml` file and instead uses an
environment variable config override to update **Device.ProfilesDir**.

This resolves issue #149.

To test, install the main edgex snap, install the snap built from this PR, start a command to watch log output, and then start the service:

```
$ sudo snap install edgexfoundry
$ sudo snap install edgex-device-mqtt_*.snap --dangerous
$ sudo snap logs edgex-device-mqtt.device-mqtt -f | grep "Environment override"
```
**Note** -- the `--dangerous` flag is used to install an unsigned snap (i.e. a snap that's been built locally).

In another terminal run:

```$ sudo snap start edgex-device-mqtt.device-mqtt```

You should see the following log message output:

> 2020-06-04T14:46:19Z edgex-device-mqtt.device-mqtt[4899]: level=INFO ts=2020-06-04T14:46:19.436460404Z app=edgex-device-mqtt source=environment.go:327 msg="Environment override of 'Device.ProfilesDir' by environment variable: DEVICE_PROFILESDIR=/var/snap/edgex-device-mqtt/x1/config/device-mqtt/res"
