### PR TITLE
fix: Set default configuration value to prevent service panic error

### DIFF
--- a/internal/driver/config_test.go
+++ b/internal/driver/config_test.go
@@ -7,7 +7,7 @@
 package driver
 
 import (
-	"strings"
+	"fmt"
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
@@ -38,21 +38,10 @@ func TestCreateConnectionInfo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Fail to create connectionIfo. Error: %v", err)
 	}
-	if connectionInfo.Schema != schema || connectionInfo.Host != host || connectionInfo.Port != port ||
+	if connectionInfo.Schema != schema || connectionInfo.Host != host || fmt.Sprintf("%d", connectionInfo.Port) != port ||
 		connectionInfo.User != user || connectionInfo.Password != password || connectionInfo.ClientId != clientId ||
 		connectionInfo.Topic != topic {
 		t.Fatalf("Unexpect test result. %v should match to %v ", connectionInfo, protocols)
-	}
-}
-
-func TestCreateConnectionInfo_fail(t *testing.T) {
-	protocols := map[string]models.ProtocolProperties{
-		Protocol: {},
-	}
-
-	_, err := CreateConnectionInfo(protocols)
-	if err == nil || !strings.Contains(err.Error(), "unable to load config") {
-		t.Fatalf("Unexpect test result, config should be fail to load")
 	}
 }
 
@@ -85,13 +74,5 @@ func TestCreateDriverConfig(t *testing.T) {
 		diverConfig.ConnEstablishingRetry != 10 || diverConfig.ConnRetryWaitTime != 5 {
 
 		t.Fatalf("Unexpect test result, driver config doesn't correct load")
-	}
-}
-
-func TestCreateDriverConfig_fail(t *testing.T) {
-	configs := map[string]string{}
-	_, err := CreateDriverConfig(configs)
-	if err == nil || !strings.Contains(err.Error(), "unable to load config") {
-		t.Fatalf("Unexpect test result, config should be fail to load")
 	}
 }

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -104,7 +104,7 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 
 	uri := &url.URL{
 		Scheme: strings.ToLower(connectionInfo.Schema),
-		Host:   fmt.Sprintf("%s:%s", connectionInfo.Host, connectionInfo.Port),
+		Host:   fmt.Sprintf("%s:%d", connectionInfo.Host, connectionInfo.Port),
 		User:   url.UserPassword(connectionInfo.User, connectionInfo.Password),
 	}
 
@@ -194,7 +194,7 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 
 	uri := &url.URL{
 		Scheme: strings.ToLower(connectionInfo.Schema),
-		Host:   fmt.Sprintf("%s:%s", connectionInfo.Host, connectionInfo.Port),
+		Host:   fmt.Sprintf("%s:%d", connectionInfo.Host, connectionInfo.Port),
 		User:   url.UserPassword(connectionInfo.User, connectionInfo.Password),
 	}
 

--- a/internal/driver/protocolpropertykey.go
+++ b/internal/driver/protocolpropertykey.go
@@ -40,4 +40,20 @@ const (
 
 	ConnEstablishingRetry = "ConnEstablishingRetry"
 	ConnRetryWaitTime     = "ConnRetryWaitTime"
+
+	DefaultSchema                = "tcp"
+	DefaultHost                  = "0.0.0.0"
+	DefaultPort                  = 1883
+	DefaultUser                  = ""
+	DefaultPassword              = ""
+	DefaultQos                   = 0
+	DefaultKeepAlive             = 3600
+	DefaultIncomingClientId      = "IncomingDataSubscriber"
+	DefaultIncomingTopic         = "DataTopic"
+	DefaultResponseClientId      = "CommandResponseSubscriber"
+	DefaultResponseTopic         = "ResponseTopic"
+	DefaultCommandClientId       = "CommandPublisher"
+	DefaultCommandTopic          = "CommandTopic"
+	DefaultConnEstablishingRetry = 10
+	DefaultConnRetryWaitTime     = 5
 )


### PR DESCRIPTION
Fix #160

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
The service will panic if IncomingUser is missing from the configuration.

Issue Number: #160


## What is the new behavior?
Set default values before loading the config


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information