### PR TITLE
fix: Modify float value checking condition

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -110,3 +110,12 @@ https://github.com/kr/pretty/blob/main/License
 
 gopkg.in/check.v1 (Unspecified) https://github.com/go-check/check/tree/v1
 https://github.com/go-check/check/blob/v1/LICENSE
+
+stretchr/testify (MIT) https://github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE
+
+pmezard/go-difflib (Unspecified) https://github.com/pmezard/go-difflib
+https://github.com/pmezard/go-difflib/blob/master/LICENSE
+
+davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
+https://github.com/davecgh/go-spew/blob/master/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/spf13/cast v1.3.0
+	github.com/stretchr/testify v1.5.1
 	golang.org/x/net v0.0.0-20190213061140-3a22650c66bd // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -13,6 +13,9 @@ import (
 
 	sdkModel "github.com/edgexfoundry/device-sdk-go/pkg/models"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -187,36 +190,60 @@ func TestNewResult_int64(t *testing.T) {
 }
 
 func TestNewResult_float32(t *testing.T) {
-	var reading interface{} = float32(123)
 	req := sdkModel.CommandRequest{
 		DeviceResourceName: "temperature",
 		Type:               sdkModel.Float32,
 	}
 
-	cmdVal, err := newResult(req, reading)
-	if err != nil {
-		t.Fatalf("Fail to create new ReadCommand result, %v", err)
+	tests := []struct {
+		name     string
+		req      sdkModel.CommandRequest
+		reading  interface{}
+		expected interface{}
+	}{
+		{"Valid string 0", req, "0", float32(0)},
+		{"Valid string 123.32", req, "123.32", float32(123.32)},
+		{"Valid float32 0", req, 0, float32(0)},
+		{"Valid float32 123.32", req, 123.32, float32(123.32)},
 	}
-	val, err := cmdVal.Float32Value()
-	if val != float32(123) || err != nil {
-		t.Errorf("Convert new result(%v) failed, error: %v", val, err)
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			cmdVal, err := newResult(req, testCase.reading)
+			require.NoError(t, err)
+			result, err := cmdVal.Float32Value()
+			require.NoError(t, err)
+
+			assert.Equal(t, testCase.expected, result)
+		})
 	}
 }
 
 func TestNewResult_float64(t *testing.T) {
-	var reading interface{} = float64(0.123)
 	req := sdkModel.CommandRequest{
 		DeviceResourceName: "temperature",
 		Type:               sdkModel.Float64,
 	}
 
-	cmdVal, err := newResult(req, reading)
-	if err != nil {
-		t.Fatalf("Fail to create new ReadCommand result, %v", err)
+	tests := []struct {
+		name     string
+		req      sdkModel.CommandRequest
+		reading  interface{}
+		expected interface{}
+	}{
+		{"Valid string 0", req, "0", float64(0)},
+		{"Valid string 0.123", req, "0.123", 0.123},
+		{"Valid float64 0", req, 0, float64(0)},
+		{"Valid float64 0.123", req, 0.123, 0.123},
 	}
-	val, err := cmdVal.Float64Value()
-	if val != float64(0.123) || err != nil {
-		t.Errorf("Convert new result(%v) failed, error: %v", val, err)
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			cmdVal, err := newResult(req, testCase.reading)
+			require.NoError(t, err)
+			result, err := cmdVal.Float64Value()
+			require.NoError(t, err)
+
+			assert.Equal(t, testCase.expected, result)
+		})
 	}
 }
 
@@ -403,40 +430,6 @@ func TestNewResult_string(t *testing.T) {
 	}
 	val, err := cmdVal.StringValue()
 	if val != "test string" || err != nil {
-		t.Errorf("Convert new result(%v) failed, error: %v", val, err)
-	}
-}
-
-func TestNewResult_stringToFloat32(t *testing.T) {
-	var reading interface{} = "123.0"
-	req := sdkModel.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               sdkModel.Float32,
-	}
-
-	cmdVal, err := newResult(req, reading)
-	if err != nil {
-		t.Fatalf("Fail to create new ReadCommand result, %v", err)
-	}
-	val, err := cmdVal.Float32Value()
-	if val != float32(123) || err != nil {
-		t.Errorf("Convert new result(%v) failed, error: %v", val, err)
-	}
-}
-
-func TestNewResult_stringToFloat64(t *testing.T) {
-	var reading interface{} = "123.0"
-	req := sdkModel.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               sdkModel.Float64,
-	}
-
-	cmdVal, err := newResult(req, reading)
-	if err != nil {
-		t.Fatalf("Fail to create new ReadCommand result, %v", err)
-	}
-	val, err := cmdVal.Float64Value()
-	if val != float64(123) || err != nil {
 		t.Errorf("Convert new result(%v) failed, error: %v", val, err)
 	}
 }

--- a/internal/driver/readingchecker.go
+++ b/internal/driver/readingchecker.go
@@ -92,11 +92,11 @@ func checkFloatValueRange(valueType sdkModel.ValueType, val float64) bool {
 	var isValid = false
 	switch valueType {
 	case sdkModel.Float32:
-		if math.Abs(val) >= math.SmallestNonzeroFloat32 && math.Abs(val) <= math.MaxFloat32 {
+		if !math.IsNaN(val) && math.Abs(val) <= math.MaxFloat32 {
 			isValid = true
 		}
 	case sdkModel.Float64:
-		if math.Abs(val) >= math.SmallestNonzeroFloat64 && math.Abs(val) <= math.MaxFloat64 {
+		if !math.IsNaN(val) && !math.IsInf(val, 0) {
 			isValid = true
 		}
 	}


### PR DESCRIPTION
fix #143

Signed-off-by: weichou <weichou1229@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
If the float value is zero, the device service will throw error "parse reading fail. Reading 0 is out of the value type(11)'s range"

Issue Number: #143 


## What is the new behavior?
Modify float value checking condition to make the zero value is valid

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## Are there any new imports or modules? If so, what are they used for and why?
github.com/stretchr/testify v1.5.1
Import stretchr/testify v1.5.1 and dependency libs for writing tests.

## Are there any specific instructions or things that should be known prior to reviewing?
This fix is can refer to edgexfoundry/device-sdk-go#358

## Other information