### PR TITLE
fix: Return error instead of the panic if required config not found

### DIFF
--- a/internal/driver/config.go
+++ b/internal/driver/config.go
@@ -83,7 +83,9 @@ func load(config map[string]string, des interface{}) error {
 		valueField := val.Field(i)
 
 		val, ok := config[typeField.Name]
-		if !ok {
+		if !ok &&
+			typeField.Name != IncomingUser && typeField.Name != IncomingPassword &&
+			typeField.Name != ResponseUser && typeField.Name != ResponsePassword {
 			return fmt.Errorf(errorMessage, typeField.Name)
 		}
 

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -64,7 +64,7 @@ func (d *Driver) Initialize(lc logger.LoggingClient, asyncCh chan<- *sdkModel.As
 
 	config, err := CreateDriverConfig(device.DriverConfigs())
 	if err != nil {
-		panic(fmt.Errorf("read MQTT driver configuration failed: %v", err))
+		return fmt.Errorf("read MQTT driver configuration failed: %w", err)
 	}
 	d.Config = config
 


### PR DESCRIPTION
Fix #160

Signed-off-by: weichou <weichou1229@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Service will panic when the config is unable to load.

Issue Number: #160 

## What is the new behavior?
Return error instead of the panic if required config not found and modify the config username and pwd to optional field.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information