### PR TITLE
fix: Change "."s in profile name to "-"s

### DIFF
--- a/cmd/res/devices/mqtt.test.device-autoevents.toml
+++ b/cmd/res/devices/mqtt.test.device-autoevents.toml
@@ -1,7 +1,7 @@
 # Pre-define Devices
 [[DeviceList]]
   Name = 'MQTT-test-device'
-  ProfileName = 'Test.Device.MQTT.Profile'
+  ProfileName = 'Test-Device-MQTT-Profile'
   Description = 'MQTT device is created for test purpose'
   Labels = [ 'MQTT', 'test' ]
   [DeviceList.Protocols]

--- a/cmd/res/devices/mqtt.test.device.toml
+++ b/cmd/res/devices/mqtt.test.device.toml
@@ -1,7 +1,7 @@
 # Pre-define Devices
 [[DeviceList]]
   Name = 'MQTT-test-device'
-  ProfileName = 'Test.Device.MQTT.Profile'
+  ProfileName = 'Test-Device-MQTT-Profile'
   Description = 'MQTT device is created for test purpose'
   Labels = [ 'MQTT', 'test' ]
   [DeviceList.Protocols]

--- a/cmd/res/profiles/mqtt.test.device.profile.yml
+++ b/cmd/res/profiles/mqtt.test.device.profile.yml
@@ -1,4 +1,4 @@
-name: "Test.Device.MQTT.Profile"
+name: "Test-Device-MQTT-Profile"
 manufacturer: "Dell"
 model: "MQTT-2"
 labels:


### PR DESCRIPTION
c## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-mqtt-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
Profile as invalid "." characters in the name

## Issue Number: #283


## What is the new behavior?
"."s in Profile name changed to "-"s

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
