### PR TITLE
feat: add UseMqttLevels capability to pass in metadata

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -63,9 +63,6 @@ https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
 hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
 https://github.com/hashicorp/golang-lru/blob/master/LICENSE
 
-gopkg.in/mgo v2 (unspecified) https://github.com/go-mgo/mgo/tree/v2
-https://github.com/go-mgo/mgo/blob/v2/LICENSE
-
 gopkg.in/yaml v2 (Apache 2.0) https://github.com/go-yaml/yaml/tree/v2
 https://github.com/go-yaml/yaml/blob/v2/LICENSE
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Overview
 MQTT Micro Service - device service for connecting a MQTT topic to EdgeX acting like a device/sensor feed.
 ## Usage
-Users can refer to [the document](https://docs.edgexfoundry.org/1.2/examples/Ch-ExamplesAddingMQTTDevice) to learn how to use this device service.
+Users can refer to [the document](https://docs.edgexfoundry.org/2.0/examples/Ch-ExamplesAddingMQTTDevice) to learn how to use this device service.
 
 ## Community
 - Chat: https://edgexfoundry.slack.com

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -100,8 +100,15 @@ ConnRetryWaitTime = 5
 AuthMode = "none"
 CredentialsPath = "credentials"
 
+# Comment out/remove when using multi-level topics
 IncomingTopic = "DataTopic"
-responseTopic = "ResponseTopic"
+ResponseTopic = "ResponseTopic"
+UseTopicLevels = false
+
+# Uncomment to use multi-level topics
+# IncomingTopic = "incoming/data/#"
+# ResponseTopic = "command/response/#"
+# UseTopicLevels = true
 
     [MQTTBrokerInfo.Writable]
     # ResponseFetchInterval specifies the retry interval(milliseconds) to fetch the command response from the MQTT broker

--- a/cmd/res/devices/mqtt.test.device.toml
+++ b/cmd/res/devices/mqtt.test.device.toml
@@ -6,7 +6,10 @@
   Labels = [ "MQTT", "test" ]
   [DeviceList.Protocols]
     [DeviceList.Protocols.mqtt]
+       # Comment out/remove below to use multi-level topics
        CommandTopic = "CommandTopic"
+       # Uncomment below to use multi-level topics
+       # CommandTopic = "command/MQTT-test-device"
 #    [[DeviceList.AutoEvents]]
 #       Interval = "20s"
 #       OnChange = false

--- a/cmd/res/profiles/mqtt.test.device.profile.yml
+++ b/cmd/res/profiles/mqtt.test.device.profile.yml
@@ -8,20 +8,20 @@ deviceResources:
 -
   name: randfloat32
   isHidden: true
-  description: "device random number with Base64 encoding"
+  description: "random 32 bit float"
   properties:
     valueType: "Float32"
-    readWrite: "R"
+    readWrite: "RW"
     defaultValue: "0.00"
     minimum: "0.00"
     maximum: "100.00"
 -
   name: randfloat64
   isHidden: true
-  description: "device random number with e notion"
+  description: "random 64 bit float"
   properties:
     valueType: "Float64"
-    readWrite: "R"
+    readWrite: "RW"
     defaultValue: "0.00"
     minimum: "0.00"
     maximum: "100.00"
@@ -69,3 +69,10 @@ deviceCommands:
   isHidden: false
   resourceOperations:
     - { deviceResource: "message" }
+-
+  name: randfloat32andfloat64
+  readWrite: "RW"
+  isHidden: false
+  resourceOperations:
+    - { deviceResource: "randfloat32" }
+    - { deviceResource: "randfloat64" }

--- a/cmd/res/profiles/mqtt.test.device.profile.yml
+++ b/cmd/res/profiles/mqtt.test.device.profile.yml
@@ -70,9 +70,11 @@ deviceCommands:
   resourceOperations:
     - { deviceResource: "message" }
 -
-  name: randfloat32andfloat64
+  name: allValues
   readWrite: "RW"
   isHidden: false
   resourceOperations:
     - { deviceResource: "randfloat32" }
     - { deviceResource: "randfloat64" }
+    - { deviceResource: "ping" }
+    - { deviceResource: "message" }

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ require (
 	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0
+	github.com/google/uuid v1.2.0
 	github.com/spf13/cast v1.4.1
 	github.com/stretchr/testify v1.7.0
-	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
 )
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0
-	github.com/google/uuid v1.2.0
+	github.com/google/uuid v1.3.0
 	github.com/spf13/cast v1.4.1
 	github.com/stretchr/testify v1.7.0
 )

--- a/internal/driver/config.go
+++ b/internal/driver/config.go
@@ -51,8 +51,9 @@ type MQTTBrokerInfo struct {
 	AuthMode        string
 	CredentialsPath string
 
-	IncomingTopic string
-	ResponseTopic string
+	IncomingTopic  string
+	ResponseTopic  string
+	UseTopicLevels bool
 
 	Writable WritableInfo
 }

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -22,8 +22,8 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 
 	"github.com/eclipse/paho.mqtt.golang"
+	"github.com/google/uuid"
 	"github.com/spf13/cast"
-	"gopkg.in/mgo.v2/bson"
 )
 
 var once sync.Once
@@ -67,7 +67,7 @@ func (d *Driver) Initialize(lc logger.LoggingClient, asyncCh chan<- *sdkModel.As
 		return errors.NewCommonEdgeX(errors.Kind(err), fmt.Sprintf("unable to listen for changes for '%s' custom configuration", WritableInfoSectionName), err)
 	}
 
-	client, err := createMqttClient(d.serviceConfig)
+	client, err := d.createMqttClient(d.serviceConfig)
 	if err != nil {
 		return errors.NewCommonEdgeX(errors.Kind(err), "unable to initial the MQTT client", err)
 	}
@@ -117,22 +117,29 @@ func (d *Driver) handleReadCommandRequest(req sdkModel.CommandRequest, topic str
 	var retained = false
 
 	var method = "get"
-	var cmdUuid = bson.NewObjectId().Hex()
+	var cmdUuid = uuid.NewString()
+
 	var cmd = req.DeviceResourceName
+	var payload []byte
 
-	data := make(map[string]interface{})
-	data["uuid"] = cmdUuid
-	data["method"] = method
-	data["cmd"] = cmd
+	if d.serviceConfig.MQTTBrokerInfo.UseTopicLevels {
+		topic = fmt.Sprintf("%s/%s/%s/%s", topic, cmd, method, cmdUuid)
+		// will publish empty payload
+	} else {
+		data := make(map[string]interface{})
+		data["uuid"] = cmdUuid
+		data["method"] = method
+		data["cmd"] = cmd
 
-	jsonData, err := json.Marshal(data)
-	if err != nil {
-		return result, err
+		payload, err = json.Marshal(data)
+		if err != nil {
+			return result, err
+		}
 	}
 
-	driver.mqttClient.Publish(topic, qos, retained, jsonData)
+	driver.mqttClient.Publish(topic, qos, retained, payload)
 
-	driver.Logger.Debugf("Publish command: %v", string(jsonData))
+	driver.Logger.Debugf("Publish command: %v", string(payload))
 
 	// fetch response from MQTT broker after publish command successful
 	cmdResponse, ok := d.fetchCommandResponse(cmdUuid)
@@ -176,34 +183,36 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 }
 
 func (d *Driver) handleWriteCommandRequest(req sdkModel.CommandRequest, topic string, param *sdkModel.CommandValue) errors.EdgeX {
-	var err error
 	var qos = byte(0)
 	var retained = false
 
 	var method = "set"
-	var cmdUuid = bson.NewObjectId().Hex()
+	var cmdUuid = uuid.NewString()
 	var cmd = req.DeviceResourceName
-
+	var payload []byte
 	data := make(map[string]interface{})
-	data["uuid"] = cmdUuid
-	data["method"] = method
-	data["cmd"] = cmd
 
 	commandValue, err := newCommandValue(req.Type, param)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
+	}
+	if d.serviceConfig.MQTTBrokerInfo.UseTopicLevels {
+		topic = fmt.Sprintf("%s/%s/%s/%s", topic, cmd, method, cmdUuid)
+		data[cmd] = commandValue
 	} else {
+		data["uuid"] = cmdUuid
+		data["method"] = method
+		data["cmd"] = cmd
 		data[cmd] = commandValue
 	}
 
-	jsonData, err := json.Marshal(data)
+	payload, err = json.Marshal(data)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
+	driver.mqttClient.Publish(topic, qos, retained, payload)
 
-	driver.mqttClient.Publish(topic, qos, retained, jsonData)
-
-	driver.Logger.Debugf("Publish command: %v", string(jsonData))
+	driver.Logger.Debugf("Publish command: %v", string(payload))
 
 	//wait and fetch response from CommandResponses map
 	cmdResponse, ok := d.fetchCommandResponse(cmdUuid)
@@ -378,7 +387,7 @@ func (d *Driver) RemoveDevice(deviceName string, protocols map[string]models.Pro
 	return nil
 }
 
-func createMqttClient(serviceConfig *ServiceConfig) (mqtt.Client, errors.EdgeX) {
+func (d *Driver) createMqttClient(serviceConfig *ServiceConfig) (mqtt.Client, errors.EdgeX) {
 	var scheme = serviceConfig.MQTTBrokerInfo.Schema
 	var brokerUrl = serviceConfig.MQTTBrokerInfo.Host
 	var brokerPort = serviceConfig.MQTTBrokerInfo.Port
@@ -399,7 +408,7 @@ func createMqttClient(serviceConfig *ServiceConfig) (mqtt.Client, errors.EdgeX) 
 
 	var client mqtt.Client
 	for i := 0; i <= serviceConfig.MQTTBrokerInfo.ConnEstablishingRetry; i++ {
-		client, err = mqttClient(mqttClientId, uri, keepAlive)
+		client, err = d.getMqttClient(mqttClientId, uri, keepAlive)
 		if err != nil && i >= serviceConfig.MQTTBrokerInfo.ConnEstablishingRetry {
 			return nil, errors.NewCommonEdgeXWrapper(err)
 		} else if err != nil {
@@ -412,7 +421,7 @@ func createMqttClient(serviceConfig *ServiceConfig) (mqtt.Client, errors.EdgeX) 
 	return client, nil
 }
 
-func mqttClient(clientID string, uri *url.URL, keepAlive int) (mqtt.Client, error) {
+func (d *Driver) getMqttClient(clientID string, uri *url.URL, keepAlive int) (mqtt.Client, error) {
 	driver.Logger.Infof("Create MQTT client and connection: uri=%v clientID=%v ", uri.String(), clientID)
 	opts := mqtt.NewClientOptions()
 	opts.AddBroker(fmt.Sprintf("%s://%s", uri.Scheme, uri.Host))
@@ -422,7 +431,7 @@ func mqttClient(clientID string, uri *url.URL, keepAlive int) (mqtt.Client, erro
 	opts.SetPassword(password)
 	opts.SetKeepAlive(time.Second * time.Duration(keepAlive))
 	opts.SetAutoReconnect(true)
-	opts.OnConnect = onConnectHandler
+	opts.OnConnect = d.onConnectHandler
 
 	client := mqtt.NewClient(opts)
 	token := client.Connect()
@@ -433,12 +442,12 @@ func mqttClient(clientID string, uri *url.URL, keepAlive int) (mqtt.Client, erro
 	return client, nil
 }
 
-func onConnectHandler(client mqtt.Client) {
+func (d *Driver) onConnectHandler(client mqtt.Client) {
 	qos := byte(driver.serviceConfig.MQTTBrokerInfo.Qos)
 	responseTopic := driver.serviceConfig.MQTTBrokerInfo.ResponseTopic
 	incomingTopic := driver.serviceConfig.MQTTBrokerInfo.IncomingTopic
 
-	token := client.Subscribe(incomingTopic, qos, onIncomingDataReceived)
+	token := client.Subscribe(incomingTopic, qos, d.onIncomingDataReceived)
 	if token.Wait() && token.Error() != nil {
 		client.Disconnect(0)
 		driver.Logger.Errorf("could not subscribe to topic '%s': %s",
@@ -447,7 +456,7 @@ func onConnectHandler(client mqtt.Client) {
 	}
 	driver.Logger.Infof("Subscribed to topic '%s' for receiving the async reading", incomingTopic)
 
-	token = client.Subscribe(responseTopic, qos, onCommandResponseReceived)
+	token = client.Subscribe(responseTopic, qos, d.onCommandResponseReceived)
 	if token.Wait() && token.Error() != nil {
 		client.Disconnect(0)
 		driver.Logger.Errorf("could not subscribe to topic '%s': %s",

--- a/internal/driver/incominglistener.go
+++ b/internal/driver/incominglistener.go
@@ -9,6 +9,7 @@ package driver
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/edgexfoundry/device-sdk-go/v2/pkg/models"
 	"github.com/edgexfoundry/device-sdk-go/v2/pkg/service"
@@ -21,27 +22,46 @@ const (
 	cmd  = "cmd"
 )
 
-func onIncomingDataReceived(client mqtt.Client, message mqtt.Message) {
-	var data map[string]interface{}
-	json.Unmarshal(message.Payload(), &data)
+func (d *Driver) onIncomingDataReceived(client mqtt.Client, message mqtt.Message) {
+	var deviceName string
+	var resourceName string
+	var reading interface{}
 
-	nameVal, ok := data[name]
-	if !ok {
-		driver.Logger.Errorf("[Incoming listener] Incoming reading ignored, reading data `%v` should contain the field `%s` to indicate the device name", data, name)
-		return
-	}
-	cmdVal, ok := data[cmd]
-	if !ok {
-		driver.Logger.Errorf("[Incoming listener] Incoming reading ignored, reading data `%v` should contain the field `%s` to indicate the device resource name", data, cmd)
-		return
-	}
-	deviceName := fmt.Sprintf("%s", nameVal)
-	resourceName := fmt.Sprintf("%s", cmdVal)
+	if d.serviceConfig.MQTTBrokerInfo.UseTopicLevels {
+		incomingTopic := message.Topic()
+		subscribedTopic := d.serviceConfig.MQTTBrokerInfo.IncomingTopic
+		subscribedTopic = strings.Replace(subscribedTopic, "#", "", -1)
+		incomingTopic = strings.Replace(incomingTopic, subscribedTopic, "", -1)
+		metaData := strings.Split(incomingTopic, "/")
+		if len(metaData) != 2 {
+			driver.Logger.Errorf("[Incoming listener] Incoming reading ignored, incoming topic data should have format .../<device_name>/<resource_name>: `%s`", incomingTopic)
+			return
+		}
+		deviceName = metaData[0]
+		resourceName = metaData[1]
+		reading = string(message.Payload())
+	} else {
+		var data map[string]interface{}
+		json.Unmarshal(message.Payload(), &data)
 
-	reading, ok := data[resourceName]
-	if !ok {
-		driver.Logger.Errorf("[Incoming listener] Incoming reading ignored, reading data `%v` should contain the field `%s` with the actual reading value", data, resourceName)
-		return
+		nameVal, ok := data[name]
+		if !ok {
+			driver.Logger.Errorf("[Incoming listener] Incoming reading ignored, reading data `%v` should contain the field `%s` to indicate the device name", data, name)
+			return
+		}
+		cmdVal, ok := data[cmd]
+		if !ok {
+			driver.Logger.Errorf("[Incoming listener] Incoming reading ignored, reading data `%v` should contain the field `%s` to indicate the device resource name", data, cmd)
+			return
+		}
+		deviceName = fmt.Sprintf("%s", nameVal)
+		resourceName = fmt.Sprintf("%s", cmdVal)
+
+		reading, ok = data[resourceName]
+		if !ok {
+			driver.Logger.Errorf("[Incoming listener] Incoming reading ignored, reading data `%v` should contain the field `%s` with the actual reading value", data, resourceName)
+			return
+		}
 	}
 
 	service := service.RunningService()

--- a/internal/driver/responselistener.go
+++ b/internal/driver/responselistener.go
@@ -19,7 +19,13 @@ func (d *Driver) onCommandResponseReceived(client mqtt.Client, message mqtt.Mess
 	if d.serviceConfig.MQTTBrokerInfo.UseTopicLevels {
 		topic := message.Topic()
 		metaData := strings.Split(topic, "/")
-		uuid = metaData[len(metaData)-1]
+
+		if len(metaData) == 0 {
+			driver.Logger.Errorf("[Response listener] Command response ignored. metaData in the message is not sufficient to retrieve UUID: topic=%v msg=%v", message.Topic(), metaData)
+			return
+		} else {
+			uuid = metaData[len(metaData)-1]
+		}
 	} else {
 		var response map[string]interface{}
 		var ok bool
@@ -27,7 +33,7 @@ func (d *Driver) onCommandResponseReceived(client mqtt.Client, message mqtt.Mess
 		json.Unmarshal(message.Payload(), &response)
 		uuid, ok = response["uuid"].(string)
 		if !ok {
-			driver.Logger.Warnf("[Response listener] Command response ignored. No UUID found in the message: topic=%v msg=%v", message.Topic(), string(message.Payload()))
+			driver.Logger.Errorf("[Response listener] Command response ignored. No UUID found in the message: topic=%v msg=%v", message.Topic(), string(message.Payload()))
 			return
 		}
 	}

--- a/internal/driver/responselistener.go
+++ b/internal/driver/responselistener.go
@@ -8,19 +8,29 @@ package driver
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/eclipse/paho.mqtt.golang"
 )
 
-func onCommandResponseReceived(client mqtt.Client, message mqtt.Message) {
-	var response map[string]interface{}
+func (d *Driver) onCommandResponseReceived(client mqtt.Client, message mqtt.Message) {
+	var uuid string
 
-	json.Unmarshal(message.Payload(), &response)
-	uuid, ok := response["uuid"].(string)
-	if ok {
-		driver.CommandResponses.Store(uuid, string(message.Payload()))
-		driver.Logger.Debugf("[Response listener] Command response received: topic=%v uuid=%v msg=%v", message.Topic(), uuid, string(message.Payload()))
+	if d.serviceConfig.MQTTBrokerInfo.UseTopicLevels {
+		topic := message.Topic()
+		metaData := strings.Split(topic, "/")
+		uuid = metaData[len(metaData)-1]
 	} else {
-		driver.Logger.Warnf("[Response listener] Command response ignored. No UUID found in the message: topic=%v msg=%v", message.Topic(), string(message.Payload()))
+		var response map[string]interface{}
+		var ok bool
+
+		json.Unmarshal(message.Payload(), &response)
+		uuid, ok = response["uuid"].(string)
+		if !ok {
+			driver.Logger.Warnf("[Response listener] Command response ignored. No UUID found in the message: topic=%v msg=%v", message.Topic(), string(message.Payload()))
+			return
+		}
 	}
+	driver.CommandResponses.Store(uuid, string(message.Payload()))
+	driver.Logger.Debugf("[Response listener] Command response received: topic=%v uuid=%v msg=%v", message.Topic(), uuid, string(message.Payload()))
 }


### PR DESCRIPTION
Closes #282

Signed-off-by:Jennifer Williams <jennifer.m.williams@intel.com>
Signed-off-by:Elizabeth J Lee <elizabeth.j.lee@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

###Related Docs PR now required (if applicable)
Related Docs PR:
https://github.com/edgexfoundry/edgex-docs/pull/566

## What is the current behavior?
Currently the MQTT device uses a payload that includes metadata for the device as a single-level topic.

## Issue Number:
Issue #282

## What is the new behavior?
Adds optional configuration for multi-level topics, which removes the metadata from the payload to leave only the values.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## New Imports

- [x] Yes
- [ ] No

## Specific Instructions
Follow documentation to enable UseTopicLevels feature.

## Other information
