### PR TITLE
build(snap): source metadata from repo

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,9 +93,9 @@ parts:
     source-type: git
     build-packages: [curl]
     override-pull: |
-      # download the metadata in AppStream format
-      curl --silent --show-error --location --remote-name \
-        https://raw.githubusercontent.com/canonical/edgex-snap-metadata/appstream/edgex-device-mqtt.metainfo.xml
+      # download the summary, description, and icon URL in AppStream format
+      curl --silent --show-error --location --output app.metainfo.xml \
+        https://github.com/farshidtz/edgex-snap-metadata/raw/appstream/${SNAPCRAFT_PROJECT_NAME}.metainfo.xml
 
       # get the version from git tag
       cd $SNAPCRAFT_PROJECT_DIR
@@ -110,4 +110,4 @@ parts:
 
       snapcraftctl set-version $VERSION
 
-    parse-info: [edgex-device-mqtt.metainfo.xml]
+    parse-info: [app.metainfo.xml]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -84,13 +84,14 @@ parts:
       install -DT "./LICENSE" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-mqtt/LICENSE"
 
-  runtime-helpers:
+  config-common:
     plugin: dump
     source: snap/local/runtime-helpers
 
   metadata:
     plugin: nil
     source-type: git
+    build-packages: [wget]
     override-pull: |
       # download the metadata in AppStream format
       # this is temp URL pending PR https://github.com/canonical/edgex-snap-metadata/pull/4
@@ -104,9 +105,9 @@ parts:
         VERSION="0.0.0"
       fi
       
-      snapcraftctl set-version $VERSION
-
       # write version to file for the build
       echo $VERSION > ./VERSION
+
+      snapcraftctl set-version $VERSION
 
     parse-info: [edgex-device-mqtt.metainfo.xml]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -91,11 +91,11 @@ parts:
   metadata:
     plugin: nil
     source-type: git
-    build-packages: [wget, ca-certificates]
+    build-packages: [curl]
     override-pull: |
       # download the metadata in AppStream format
-      # this is temp URL pending PR https://github.com/canonical/edgex-snap-metadata/pull/4
-      wget -d https://raw.githubusercontent.com/farshidtz/edgex-snap-metadata/appstream/edgex-device-mqtt.metainfo.xml
+      curl --silent --show-error --location --remote-name \
+        https://raw.githubusercontent.com/canonical/edgex-snap-metadata/appstream/edgex-device-mqtt.metainfo.xml
 
       # get the version from git tag
       cd $SNAPCRAFT_PROJECT_DIR

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -91,11 +91,11 @@ parts:
   metadata:
     plugin: nil
     source-type: git
-    build-packages: [wget]
+    build-packages: [wget, ca-certificates]
     override-pull: |
       # download the metadata in AppStream format
       # this is temp URL pending PR https://github.com/canonical/edgex-snap-metadata/pull/4
-      wget https://raw.githubusercontent.com/farshidtz/edgex-snap-metadata/appstream/edgex-device-mqtt.metainfo.xml
+      wget -d https://raw.githubusercontent.com/farshidtz/edgex-snap-metadata/appstream/edgex-device-mqtt.metainfo.xml
 
       # get the version from git tag
       cd $SNAPCRAFT_PROJECT_DIR

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -66,6 +66,9 @@ parts:
     override-build: |
       cd $SNAPCRAFT_PART_SRC
 
+      # the version is needed for the build
+      cat ./VERSION
+
       go mod tidy
       make build
 
@@ -90,15 +93,17 @@ parts:
 
   metadata:
     plugin: nil
-    source-type: git
-    build-packages: [curl]
-    override-pull: |
-      # download the summary, description, and icon URL in AppStream format
-      curl --silent --show-error --location --output app.metainfo.xml \
-        https://github.com/farshidtz/edgex-snap-metadata/raw/appstream/${SNAPCRAFT_PROJECT_NAME}.metainfo.xml
+    source: https://github.com/canonical/edgex-snap-metadata.git
+    source-branch: appstream
+    source-depth: 1
+    override-build: |
+      # install the icon at the default internal path
+      install -DT edgex-snap-icon.png \
+        $SNAPCRAFT_PART_INSTALL/meta/gui/icon.png
 
-      # get the version from git tag
+      # change to this project's repo to get the version
       cd $SNAPCRAFT_PROJECT_DIR
+
       if git describe ; then
         VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
       else
@@ -108,6 +113,6 @@ parts:
       # write version to file for the build
       echo $VERSION > ./VERSION
 
+      # set the version of this snap
       snapcraftctl set-version $VERSION
-
-    parse-info: [app.metainfo.xml]
+    parse-info: [edgex-device-mqtt.metainfo.xml]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,17 +1,8 @@
 name: edgex-device-mqtt
 base: core20
 license: Apache-2.0
-adopt-info: device-mqtt
-summary: Connect data MQTT to EdgeX using device-mqtt reference Device Service
-title: EdgeX MQTT Device Service
-description: |
-  The official reference EdgeX device-mqtt Device Service built using the 
-  device-sdk-go to interact with MQTT brokers. 
-  Initially the daemon in the snap is disabled - a device profile must be
-  provisioned externally with core-metadata or provided to device-mqtt inside
-  "$SNAP_DATA/config/device-mqtt/res" before starting.
+adopt-info: metadata
 
-# TODO: add armhf when the project supports this
 architectures:
   - build-on: amd64
   - build-on: arm64
@@ -19,7 +10,8 @@ architectures:
 grade: stable
 confinement: strict
 
-# edinburgh, geneva,hanoi = 1, ireland = 2
+# 1: edinburgh, geneva, hanoi
+# 2: ireland, jakarta
 epoch: 2
 
 slots:
@@ -64,6 +56,7 @@ parts:
       install -DT ./cmd/install/install "$SNAPCRAFT_PART_INSTALL/snap/hooks/install"
 
   device-mqtt:
+    after: [metadata]
     source: .
     plugin: make
     build-packages: [git, libzmq3-dev, zip, pkg-config]
@@ -72,14 +65,6 @@ parts:
       - go/1.17/stable
     override-build: |
       cd $SNAPCRAFT_PART_SRC
-
-      GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
-      if [ -z "$GIT_VERSION" ]; then
-        GIT_VERSION="0.0.0"
-      fi
-      snapcraftctl set-version ${GIT_VERSION}
-      # this is needed for make build
-      echo $GIT_VERSION > ./VERSION
 
       go mod tidy
       make build
@@ -99,6 +84,29 @@ parts:
       install -DT "./LICENSE" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-mqtt/LICENSE"
 
-  config-common:
+  runtime-helpers:
     plugin: dump
     source: snap/local/runtime-helpers
+
+  metadata:
+    plugin: nil
+    source-type: git
+    override-pull: |
+      # download the metadata in AppStream format
+      # this is temp URL pending PR https://github.com/canonical/edgex-snap-metadata/pull/4
+      wget https://raw.githubusercontent.com/farshidtz/edgex-snap-metadata/appstream/edgex-device-mqtt.metainfo.xml
+
+      # get the version from git tag
+      cd $SNAPCRAFT_PROJECT_DIR
+      if git describe ; then
+        VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+      else
+        VERSION="0.0.0"
+      fi
+      
+      snapcraftctl set-version $VERSION
+
+      # write version to file for the build
+      echo $VERSION > ./VERSION
+
+    parse-info: [edgex-device-mqtt.metainfo.xml]


### PR DESCRIPTION
The metadata kept in snapcraft.yaml is obsolete because it is being overridden on the store. This change will allow sourcing the central copy of metadata.

See https://github.com/canonical/edgex-snap-metadata/issues/2

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->