### PR TITLE
docs: Add deployment section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@
 ## Overview
 MQTT Micro Service - device service for connecting a MQTT topic to EdgeX acting like a device/sensor feed.
 
-## Deployment
-This component is available as docker image and snap.
+## Packaging
+This component is packaged as docker image and snap.
 
 For docker, please refer to the [Dockerfile](Dockerfile) and [Docker Compose Builder](https://github.com/edgexfoundry/edgex-compose/tree/main/compose-builder) scripts.
 
 For the snap, refer to the [snap](snap) directory.
+
+The details of the EdgeX release artifacts are available [here](https://docs.edgexfoundry.org/2.1/design/adr/devops/0010-Release-Artifacts).
 
 ## Usage
 Users can refer to [this document](https://docs.edgexfoundry.org/2.1/examples/Ch-ExamplesAddingMQTTDevice) to learn how to use this device service.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Overview
 MQTT Micro Service - device service for connecting a MQTT topic to EdgeX acting like a device/sensor feed.
 ## Usage
-Users can refer to [the document](https://docs.edgexfoundry.org/2.0/examples/Ch-ExamplesAddingMQTTDevice) to learn how to use this device service.
+Users can refer to [this document](https://docs.edgexfoundry.org/2.1/examples/Ch-ExamplesAddingMQTTDevice) to learn how to use this device service.
 
 ## Community
 - Chat: https://edgexfoundry.slack.com

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 
 ## Overview
 MQTT Micro Service - device service for connecting a MQTT topic to EdgeX acting like a device/sensor feed.
+
+## Deployment
+This component is available as docker image and snap.
+
+For docker, please refer to the [Dockerfile](Dockerfile) and [Docker Compose Builder](https://github.com/edgexfoundry/edgex-compose/tree/main/compose-builder) scripts.
+
+For the snap, refer to the [snap](snap) directory.
+
 ## Usage
 Users can refer to [this document](https://docs.edgexfoundry.org/2.1/examples/Ch-ExamplesAddingMQTTDevice) to learn how to use this device service.
 


### PR DESCRIPTION
This PR adds a ~deployment~ packaging section to reference developer information about the docker and snap packaging.

The idea is to have a similar README section across all device/app service repos. 

In addition, it bumps the docs version to 2.1.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->