### PR TITLE
fix: replace broker host config value with a valid example

### DIFF
--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -100,7 +100,7 @@ UseMessageBus = true
 
 [MQTTBrokerInfo]
 Schema = "tcp"
-Host = "0.0.0.0"
+Host = "localhost"
 Port = 1883
 Qos = 0
 KeepAlive = 3600


### PR DESCRIPTION
The `MQTTBrokerInfo` configuration section set the value of `Host` to `0.0.0.0`. There are two issues:

1. The whole configuration is about the MQTT Client, rather than the broker. Calling it broker and setting the host to `0.0.0.0` gives the false impression than this service is spinning up a broker with bind address set to `0.0.0.0` to listen on all interfaces.
2. IP address `0.0.0.0` is an invalid example for a client, because there can never be a broker at that address!

https://github.com/edgexfoundry/device-mqtt-go/blob/af7f42834155496da65d108934e36d5a2fb2bcc1/cmd/res/configuration.toml#L101-L130

I suggest changing `MQTTBrokerInfo` to `MQTTClient` in future. But in this PR, I simply change the Host to `localhost` to avoid confusion and make it a correct example.

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->