### PR TITLE
build(snap): Upgrade install/configure hooks to use snap hook 2.4.1

### DIFF
--- a/snap/local/helper-go/configure.go
+++ b/snap/local/helper-go/configure.go
@@ -60,7 +60,7 @@ var ConfToEnv = map[string]string{
 
 // configure is called by the main function
 func configure() {
-	const service = "device-mqtt"
+	const app = "device-mqtt"
 
 	log.SetComponentName("configure")
 
@@ -71,20 +71,20 @@ func configure() {
 	}
 	if envJSON != "" {
 		log.Debugf("envJSON: %s", envJSON)
-		err = hooks.HandleEdgeXConfig(service, envJSON, ConfToEnv)
+		err = hooks.HandleEdgeXConfig(app, envJSON, ConfToEnv)
 		if err != nil {
 			log.Fatalf("HandleEdgeXConfig failed: %v", err)
 		}
 	}
 
 	log.Info("Processing config options")
-	err = options.ProcessConfig(service)
+	err = options.ProcessConfig(app)
 	if err != nil {
 		log.Fatalf("could not process config options: %v", err)
 	}
 
 	log.Info("Processing autostart options")
-	err = options.ProcessAutostart(service)
+	err = options.ProcessAutostart(app)
 	if err != nil {
 		log.Fatalf("could not process autostart options: %v", err)
 	}

--- a/snap/local/helper-go/configure.go
+++ b/snap/local/helper-go/configure.go
@@ -19,13 +19,9 @@
 package main
 
 import (
-	"fmt"
-	"strings"
-
 	hooks "github.com/canonical/edgex-snap-hooks/v2"
 	"github.com/canonical/edgex-snap-hooks/v2/log"
 	"github.com/canonical/edgex-snap-hooks/v2/options"
-	"github.com/canonical/edgex-snap-hooks/v2/snapctl"
 )
 
 // Deprecated
@@ -62,72 +58,34 @@ var ConfToEnv = map[string]string{
 	"device.use-message-bus":       "DEVICE_USEMESSAGEBUS",
 }
 
-var cli *hooks.CtlCli = hooks.NewSnapCtl()
-
 // configure is called by the main function
 func configure() {
-	var debug = false
-	var err error
-	var envJSON string
+	const service = "device-mqtt"
 
-	status, err := cli.Config("debug")
-	if err != nil {
-		log.Fatalf("edgex-device-mqtt:configure: can't read value of 'debug': %v", err)
-	}
-	if status == "true" {
-		debug = true
-	}
+	log.SetComponentName("configure")
 
-	if err = hooks.Init(debug, "edgex-device-mqtt"); err != nil {
-		log.Fatalf("edgex-device-mqtt:configure: initialization failure: %v", err)
-	}
-
-	// read env var override configuration
-	envJSON, err = cli.Config(hooks.EnvConfig)
+	log.Info("Processing legacy env options")
+	envJSON, err := hooks.NewSnapCtl().Config(hooks.EnvConfig)
 	if err != nil {
 		log.Fatalf("Reading config 'env' failed: %v", err)
 	}
-
 	if envJSON != "" {
-		hooks.Debug(fmt.Sprintf("edgex-device-mqtt:configure: envJSON: %s", envJSON))
-		err = hooks.HandleEdgeXConfig("device-mqtt", envJSON, ConfToEnv)
+		log.Debugf("envJSON: %s", envJSON)
+		err = hooks.HandleEdgeXConfig(service, envJSON, ConfToEnv)
 		if err != nil {
 			log.Fatalf("HandleEdgeXConfig failed: %v", err)
 		}
 	}
 
-	// If autostart is not explicitly set, default to "no"
-	// as only example service configuration and profiles
-	// are provided by default.
-	autostart, err := snapctl.Get("autostart").Run()
+	log.Info("Processing config options")
+	err = options.ProcessConfig(service)
 	if err != nil {
-		log.Fatalf("Reading config 'autostart' failed: %v", err)
-	}
-	if autostart == "" {
-		log.Debug("autostart is NOT set, initializing to 'no'")
-		autostart = "no"
-	}
-	autostart = strings.ToLower(autostart)
-	log.Debugf("autostart=%s", autostart)
-
-	// services are stopped/disabled by default in the install hook
-	switch autostart {
-	case "true", "yes":
-		err = snapctl.Start("device-mqtt").Enable().Run()
-		if err != nil {
-			log.Fatalf("Can't start service: %s", err)
-		}
-	case "false", "no":
-		// no action necessary
-	default:
-		log.Fatalf("Invalid value for 'autostart': %s", autostart)
+		log.Fatalf("could not process config options: %v", err)
 	}
 
-	log.SetComponentName("configure")
-
-	log.Info("Processing options")
-	err = options.ProcessAppConfig("device-mqtt")
+	log.Info("Processing autostart options")
+	err = options.ProcessAutostart(service)
 	if err != nil {
-		log.Fatalf("could not process options: %v", err)
+		log.Fatalf("could not process autostart options: %v", err)
 	}
 }

--- a/snap/local/helper-go/install.go
+++ b/snap/local/helper-go/install.go
@@ -40,8 +40,8 @@ func installDevices() error {
 	path := "/config/device-mqtt/res/devices"
 
 	err := hooks.CopyDir(
-		hooks.Snap+path,
-		hooks.SnapData+path)
+		env.Snap+path,
+		env.SnapData+path)
 	if err != nil {
 		return err
 	}
@@ -53,8 +53,8 @@ func installDevProfiles() error {
 	path := "/config/device-mqtt/res/profiles"
 
 	err := hooks.CopyDir(
-		hooks.Snap+path,
-		hooks.SnapData+path)
+		env.Snap+path,
+		env.SnapData+path)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Use library function for autostart processing and config processing
- Replace deprecated hooks package with env package

Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?) [test suite](https://github.com/canonical/edgex-snap-testing/tree/main/test/suites/device-mqtt) passed with full config test enabled
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Install and setup:
```
snap install edgex-device-mqtt_2.3.0-dev.13_amd64.snap --devmode
snap install edgexfoundry
snap connect edgexfoundry:edgex-secretstore-token edgex-device-mqtt:edgex-secretstore-token
```
2. Validate that autostart works as expected:
```
$ snap set edgex-device-mqtt autostart=true
$ snap services edgex-device-mqtt
Service                        Startup  Current  Notes
edgex-device-mqtt.device-mqtt  enabled  active   -
$ snap logs edgex-device-mqtt -n=5
msg="Starting device-mqtt 2.3.0-dev.13 "
```
```
$ snap set edgex-device-mqtt autostart=false
$ snap services edgex-device-mqtt
Service                        Startup   Current   Notes
$ snap logs edgex-device-mqtt -n=5
edgex-device-mqtt.device-mqtt  disabled  inactive  -
...
Stopped Service for snap application edgex-device-mqtt.device-mqtt.
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->