### PR TITLE
feat!: Remove ZeroMQ MessageBus capability

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -135,9 +135,6 @@ https://github.com/leodido/go-urn
 edgexfoundry/go-mod-messaging (Apache 2.0) https://github.com/edgexfoundry/go-mod-messaging/v3
 https://github.com/edgexfoundry/go-mod-messaging/blob/master/LICENSE
 
-pebbe/zmq4 (BSD-2) https://github.com/pebbe/zmq4
-https://github.com/pebbe/zmq4/blob/master/LICENSE.txt
-
 golang.org/x/net (Unspecified) https://github.com/golang/net
 https://github.com/golang/net/blob/master/LICENSE
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM ${BASE} AS builder
 
 ARG ADD_BUILD_TAGS=""
 ARG MAKE="make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS build"
-ARG ALPINE_PKG_BASE="make git openssh-client gcc libc-dev zeromq-dev libsodium-dev"
+ARG ALPINE_PKG_BASE="make git openssh-client"
 ARG ALPINE_PKG_EXTRA=""
 
 # Install our build time packages.
@@ -40,7 +40,7 @@ LABEL license='VSPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2020-2021: IoTech Ltd'
 
 # dumb-init needed for injected secure bootstrapping entrypoint script when run in secure mode.
-RUN apk add --update --no-cache zeromq dumb-init
+RUN apk add --update --no-cache dumb-init
 
 COPY --from=builder /device-mqtt-go/cmd /
 COPY --from=builder /device-mqtt-go/LICENSE /

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.4.2
-	github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.5
+	github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.6
 	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.5
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.2
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.5 h1:8jvPXdI06yGOH3qw3BgN/xutHVoAgUU+Q946rc89C9w=
-github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.5/go.mod h1:9tfeovR5aXyNb4/kB6ymWvwFUYABvjt9vy3UPyEN6qg=
+github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.6 h1:4hvEOdtLUjWBqvc9ZpdYLqLhrXzZRwW86RsgWJBmSkQ=
+github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.6/go.mod h1:9tfeovR5aXyNb4/kB6ymWvwFUYABvjt9vy3UPyEN6qg=
 github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.5 h1:3WMWQ0oi++KFrau/e8BOTqgzORCa3G7bLG0w/wO72Io=
 github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.5/go.mod h1:cGXMUtbbzw+npJpMcFHPlXIN+ZPF71aiimhJ6v8kaSc=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.2 h1:xp5MsP+qf/fuJxy8fT7k1N+c4j4C6w04qMCBXm6id7o=

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -62,8 +62,7 @@ parts:
     after: [metadata]
     source: .
     plugin: make
-    build-packages: [git, libzmq3-dev, zip, pkg-config]
-    stage-packages: [libzmq5]
+    build-packages: [git, zip, pkg-config]
     build-snaps:
       - go/1.18/stable
     override-build: |


### PR DESCRIPTION
Signed-off-by: Valina Li <valina.li@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
run `make build` and `make test`,
edgex-compose run `make run no-secty mqtt-broker'
run `export EDGEX_SECURITY_SECRET_STORE=false; ./device-mqtt -cp` under device-mqtt-go/cmd
verified all completed successfully without CGO and ZMQ libs

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->