### PR TITLE
fix: [WIP BUG] Add ProfilesDir & DevicesDir to local config

### DIFF
--- a/cmd/res/configuration.yaml
+++ b/cmd/res/configuration.yaml
@@ -27,6 +27,11 @@ MessageBus:
   # Default MQTT & NATS Specific options that need to be here to enable environment variable overrides of them
     ClientId: "device-mqtt"
 
+Device:
+  # These have common values (currently), but must be here for service local env overrides to apply when customized
+  ProfilesDir: "./res/profiles"
+  DevicesDir: "./res/devices"
+
 MQTTBrokerInfo:
   Schema: "tcp"
   Host: "localhost"
@@ -57,8 +62,3 @@ MQTTBrokerInfo:
   Writable:
     # ResponseFetchInterval specifies the retry interval(milliseconds) to fetch the command response from the MQTT broker
     ResponseFetchInterval: 500
-
-Device:
-  # These have common values (currently), but must be here for service local env overrides to apply when customized
-  ProfilesDir: "./res/profiles"
-  DevicesDir: "./res/devices"

--- a/cmd/res/configuration.yaml
+++ b/cmd/res/configuration.yaml
@@ -17,7 +17,7 @@ Service:
 # uncomment when running from command-line in hybrid mode with -cp -o flags
 # Clients:
 #   core-metadata:
-#     Host: "localhost" 
+#     Host: "localhost"
 # Registry:
 #   Host: "localhost"
 
@@ -57,3 +57,8 @@ MQTTBrokerInfo:
   Writable:
     # ResponseFetchInterval specifies the retry interval(milliseconds) to fetch the command response from the MQTT broker
     ResponseFetchInterval: 500
+
+Device:
+  # These have common values (currently), but must be here for service local env overrides to apply when customized
+  ProfilesDir: "./res/profiles"
+  DevicesDir: "./res/devices"


### PR DESCRIPTION
  This is so that the values can be overriden with Envs

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->