### PR TITLE
build(snap): Upgrade snap base to core22

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,11 +27,6 @@ plugs:
     interface: content
     target: $SNAP_DATA/config/device-mqtt
 
-  # deprecated
-  device-config:
-    interface: content
-    target: $SNAP_DATA/config/device-mqtt
-
 apps:
   device-mqtt:
     command: bin/device-mqtt --configDir $SNAP_DATA/config/device-mqtt/res --configProvider --registry

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: edgex-device-mqtt
-base: core20
+base: core22
 license: Apache-2.0
 summary: EdgeX MQTT Device Service
 description: Refer to https://snapcraft.io/edgex-device-mqtt
@@ -34,7 +34,6 @@ plugs:
 
 apps:
   device-mqtt:
-    adapter: full
     command: bin/device-mqtt --configDir $SNAP_DATA/config/device-mqtt/res --configProvider --registry
     command-chain:
       - bin/source-env-file.sh
@@ -53,9 +52,9 @@ parts:
     build-snaps:
       - go/1.20/stable
     override-build: |
-      cd $SNAPCRAFT_PART_SRC
+      cd $CRAFT_PART_SRC
       make build
-      install -DT ./helper-go $SNAPCRAFT_PART_INSTALL/bin/helper-go
+      install -DT ./helper-go $CRAFT_PART_INSTALL/bin/helper-go
 
   device-mqtt:
     source: .
@@ -65,7 +64,7 @@ parts:
     build-snaps:
       - go/1.20/stable
     override-build: |
-      cd $SNAPCRAFT_PART_SRC
+      cd $CRAFT_PART_SRC
 
       if git describe ; then
         VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
@@ -74,21 +73,19 @@ parts:
       fi
 
       # set the version of this snap
-      snapcraftctl set-version $VERSION
+      craftctl set version=$VERSION
 
       # write version to file for the build
-      echo $VERSION > ./VERSION
+      echo $VERSION > VERSION
 
       make build
-      install -DT "./cmd/device-mqtt" "$SNAPCRAFT_PART_INSTALL/bin/device-mqtt"
+      install -DT "./cmd/device-mqtt" "$CRAFT_PART_INSTALL/bin/device-mqtt"
       
-      RES=$SNAPCRAFT_PART_INSTALL/config/device-mqtt/res/
+      RES=$CRAFT_PART_INSTALL/config/device-mqtt/res/
       mkdir -p $RES
-      cp    cmd/res/configuration.yaml $RES
-      cp -r cmd/res/devices $RES
-      cp -r cmd/res/profiles $RES
+      cp -r cmd/res/* $RES
 
-      DOC=$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-mqtt
+      DOC=$CRAFT_PART_INSTALL/usr/share/doc/device-mqtt
       mkdir -p $DOC
       cp Attribution.txt $DOC/Attribution.txt
       cp LICENSE $DOC/LICENSE


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Testing locally with [edgex-snap-testing suite](https://github.com/canonical/edgex-snap-testing/tree/main/test/suites/device-mqtt):
```
edgex-snap-testing$ LOCAL_SNAP=~/Desktop/edgex400/device-mqtt-go/edgex-device-mqtt_3.0.0-dev.23_amd64.snap go test -v ./test/suites/device-mqtt/
2023/04/24 11:35:06 [CLEAN]
2023/04/24 11:35:06 [exec] sudo snap remove --purge edgex-device-mqtt
[sudo] password for mengyi: 
2023/04/24 11:35:09 [stderr] snap "edgex-device-mqtt" is not installed
2023/04/24 11:35:09 [exec] sudo snap remove --purge edgexfoundry
2023/04/24 11:35:09 [stderr] snap "edgexfoundry" is not installed
2023/04/24 11:35:09 [SETUP]
2023/04/24 11:35:09 [exec] sudo snap install --dangerous /home/mengyi/Desktop/edgex400/device-mqtt-go/edgex-device-mqtt_3.0.0-dev.23_amd64.snap
2023/04/24 11:35:12 [stdout] edgex-device-mqtt 3.0.0-dev.23 installed
2023/04/24 11:35:12 [exec] sudo snap install edgexfoundry --channel=latest/edge
2023/04/24 11:35:45 [stdout] edgexfoundry (edge) 3.0.0-dev.136 from Canonical** installed
2023/04/24 11:35:45 [exec] sudo snap connect edgexfoundry:edgex-secretstore-token edgex-device-mqtt:edgex-secretstore-token
2023/04/24 11:35:47 Retry 1/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 6379 (redis), 8000 (nginx(http)), 59842 (security-proxy-auth), 8443 (nginx(https))
=== RUN   TestCommon
=== RUN   TestCommon/content_interfaces
=== RUN   TestCommon/content_interfaces/seed_secretstore_token
    exec.go:19: [exec] sudo cat /var/snap/edgexfoundry/current/secrets/device-mqtt/secrets-token.json
    exec.go:19: [exec] sudo cat /var/snap/edgex-device-mqtt/current/device-mqtt/secrets-token.json
=== RUN   TestCommon/config
=== RUN   TestCommon/config/change_service_port
    exec.go:19: [exec] sudo snap start --enable edgex-device-mqtt.device-mqtt
    exec.go:101: [stdout] Started.
    net.go:144: Retry 1/60: Waiting for ports: 59982 (device-mqtt)
    net.go:144: Retry 2/60: Waiting for ports: 59982 (device-mqtt)
    exec.go:19: [exec] sudo snap stop --disable edgex-device-mqtt.device-mqtt
    exec.go:101: [stdout] 2023-04-24T11:35:49+02:00 INFO Waiting for "snap.edgex-device-mqtt.device-mqtt.service" to stop.
    exec.go:101: [stdout] Stopped.
=== RUN   TestCommon/config/change_service_port/app_config
    exec.go:19: [exec] sudo snap stop --disable edgex-device-mqtt.device-mqtt
    exec.go:101: [stdout] Stopped.
    exec.go:19: [exec] sudo lsof -nPi :22222 || true
    net.go:256: Port 22222 is available.
    exec.go:19: [exec] sudo snap set edgex-device-mqtt apps.device-mqtt.config.edgex-config-provider='none'
    config.go:204: Copying common config file from platform snap to service snap: edgex-device-mqtt
    exec.go:19: [exec] sudo cp /snap/edgexfoundry/current/config/core-common-config-bootstrapper/res/configuration.yaml /var/snap/edgex-device-mqtt/current/config/common-config.yaml
    exec.go:19: [exec] sudo snap set edgex-device-mqtt apps.device-mqtt.config.edgex-common-config='/var/snap/edgex-device-mqtt/current/config/common-config.yaml'
    exec.go:19: [exec] sudo snap set edgex-device-mqtt apps.device-mqtt.config.service-port='22222'
    exec.go:19: [exec] sudo snap start --enable edgex-device-mqtt.device-mqtt
    exec.go:101: [stdout] Started.
    net.go:144: Retry 1/60: Waiting for ports: 22222
    net.go:144: Retry 2/60: Waiting for ports: 22222
    exec.go:19: [exec] sudo snap unset edgex-device-mqtt apps.device-mqtt.config.service-port
    exec.go:19: [exec] sudo snap restart edgex-device-mqtt.device-mqtt
    exec.go:101: [stdout] 2023-04-24T11:36:22+02:00 INFO Waiting for "snap.edgex-device-mqtt.device-mqtt.service" to stop.
    exec.go:101: [stdout] Restarted.
    net.go:144: Retry 1/60: Waiting for ports: 59982 (device-mqtt)
    net.go:144: Retry 2/60: Waiting for ports: 59982 (device-mqtt)
    exec.go:19: [exec] sudo snap unset edgex-device-mqtt apps
    exec.go:19: [exec] sudo snap stop --disable edgex-device-mqtt.device-mqtt
    exec.go:101: [stdout] 2023-04-24T11:36:54+02:00 INFO Waiting for "snap.edgex-device-mqtt.device-mqtt.service" to stop.
    exec.go:101: [stdout] Stopped.
=== RUN   TestCommon/config/change_service_port/global_config
    exec.go:19: [exec] sudo snap stop --disable edgex-device-mqtt.device-mqtt
    exec.go:101: [stdout] Stopped.
    exec.go:19: [exec] sudo lsof -nPi :33333 || true
    net.go:256: Port 33333 is available.
    exec.go:19: [exec] sudo snap set edgex-device-mqtt apps.device-mqtt.config.edgex-config-provider='none'
    config.go:204: Copying common config file from platform snap to service snap: edgex-device-mqtt
    exec.go:19: [exec] sudo cp /snap/edgexfoundry/current/config/core-common-config-bootstrapper/res/configuration.yaml /var/snap/edgex-device-mqtt/current/config/common-config.yaml
    exec.go:19: [exec] sudo snap set edgex-device-mqtt apps.device-mqtt.config.edgex-common-config='/var/snap/edgex-device-mqtt/current/config/common-config.yaml'
    exec.go:19: [exec] sudo snap set edgex-device-mqtt config.service-port='33333'
    exec.go:19: [exec] sudo snap start --enable edgex-device-mqtt.device-mqtt
    exec.go:101: [stdout] Started.
    net.go:144: Retry 1/60: Waiting for ports: 33333
    net.go:144: Retry 2/60: Waiting for ports: 33333
    exec.go:19: [exec] sudo snap unset edgex-device-mqtt config.service-port
    exec.go:19: [exec] sudo snap restart edgex-device-mqtt.device-mqtt
    exec.go:101: [stdout] 2023-04-24T11:37:27+02:00 INFO Waiting for "snap.edgex-device-mqtt.device-mqtt.service" to stop.
    exec.go:101: [stdout] Restarted.
    net.go:144: Retry 1/60: Waiting for ports: 59982 (device-mqtt)
    net.go:144: Retry 2/60: Waiting for ports: 59982 (device-mqtt)
    exec.go:19: [exec] sudo snap unset edgex-device-mqtt config
    exec.go:19: [exec] sudo snap stop --disable edgex-device-mqtt.device-mqtt
    exec.go:101: [stdout] 2023-04-24T11:37:59+02:00 INFO Waiting for "snap.edgex-device-mqtt.device-mqtt.service" to stop.
    exec.go:101: [stdout] Stopped.
=== RUN   TestCommon/config/autostart
=== RUN   TestCommon/config/autostart/set_and_unset_global_autostart
    exec.go:19: [exec] sudo snap stop --disable edgex-device-mqtt
    exec.go:101: [stdout] Stopped.
    exec.go:19: [exec] snap services edgex-device-mqtt | awk 'FNR == 2 {print $2}'
    exec.go:101: [stdout] disabled
    exec.go:19: [exec] snap services edgex-device-mqtt | awk 'FNR == 2 {print $3}'
    exec.go:101: [stdout] inactive
    exec.go:19: [exec] sudo snap set edgex-device-mqtt autostart='true'
    exec.go:19: [exec] snap services edgex-device-mqtt | awk 'FNR == 2 {print $2}'
    exec.go:101: [stdout] enabled
    exec.go:19: [exec] snap services edgex-device-mqtt | awk 'FNR == 2 {print $3}'
    exec.go:101: [stdout] active
    exec.go:19: [exec] sudo snap unset edgex-device-mqtt autostart
    exec.go:19: [exec] snap services edgex-device-mqtt | awk 'FNR == 2 {print $2}'
    exec.go:101: [stdout] enabled
    exec.go:19: [exec] snap services edgex-device-mqtt | awk 'FNR == 2 {print $3}'
    exec.go:101: [stdout] active
    exec.go:19: [exec] sudo snap set edgex-device-mqtt autostart='false'
    exec.go:101: [stdout] 2023-04-24T11:38:31+02:00 INFO Waiting for "snap.edgex-device-mqtt.device-mqtt.service" to stop.
    exec.go:19: [exec] snap services edgex-device-mqtt | awk 'FNR == 2 {print $2}'
    exec.go:101: [stdout] disabled
    exec.go:19: [exec] snap services edgex-device-mqtt | awk 'FNR == 2 {print $3}'
    exec.go:101: [stdout] inactive
    exec.go:19: [exec] sudo snap unset edgex-device-mqtt autostart
    exec.go:19: [exec] sudo snap stop --disable edgex-device-mqtt
    exec.go:101: [stdout] Stopped.
=== RUN   TestCommon/net
    exec.go:19: [exec] sudo snap start --enable edgex-device-mqtt
    exec.go:101: [stdout] Started.
=== RUN   TestCommon/net/ports_open
    net.go:144: Retry 1/60: Waiting for ports: 59982 (device-mqtt)
    net.go:144: Retry 2/60: Waiting for ports: 59982 (device-mqtt)
=== NAME  TestCommon/net
    net.go:144: Retry 1/60: Waiting for ports: 59982 (device-mqtt)
=== RUN   TestCommon/net/ports_not_listening_on_all_interfaces
    exec.go:19: [exec] sudo lsof -nPi :59982 || true
    net.go:264: Looking for '*:59982 (LISTEN)'
=== RUN   TestCommon/net/ports_listening_on_localhost
    exec.go:19: [exec] sudo lsof -nPi :59982 || true
    net.go:264: Looking for '127.0.0.1:59982 (LISTEN)'
=== NAME  TestCommon/net
    exec.go:19: [exec] sudo snap stop --disable edgex-device-mqtt
    exec.go:101: [stdout] 2023-04-24T11:39:04+02:00 INFO Waiting for "snap.edgex-device-mqtt.device-mqtt.service" to stop.
    exec.go:101: [stdout] Stopped.
=== RUN   TestCommon/packaging
=== RUN   TestCommon/packaging/semantic_snap_version
    exec.go:19: [exec] snap info edgex-device-mqtt | grep installed | awk '{print $2}'
    exec.go:101: [stdout] 3.0.0-dev.23
--- PASS: TestCommon (227.60s)
    --- PASS: TestCommon/content_interfaces (0.01s)
        --- PASS: TestCommon/content_interfaces/seed_secretstore_token (0.01s)
    --- PASS: TestCommon/config (194.80s)
        --- PASS: TestCommon/config/change_service_port (161.58s)
            --- PASS: TestCommon/config/change_service_port/app_config (64.95s)
            --- PASS: TestCommon/config/change_service_port/global_config (64.78s)
        --- PASS: TestCommon/config/autostart (33.22s)
            --- PASS: TestCommon/config/autostart/set_and_unset_global_autostart (33.22s)
    --- PASS: TestCommon/net (32.18s)
        --- PASS: TestCommon/net/ports_open (1.00s)
        --- PASS: TestCommon/net/ports_not_listening_on_all_interfaces (0.14s)
        --- PASS: TestCommon/net/ports_listening_on_localhost (0.13s)
    --- PASS: TestCommon/packaging (0.61s)
        --- PASS: TestCommon/packaging/semantic_snap_version (0.61s)
PASS
2023/04/24 11:39:34 [TEARDOWN]
2023/04/24 11:39:34 [exec] (sudo journalctl --since "2023-04-24 11:35:09" --no-pager | grep "edgex-device-mqtt"|| true) > edgex-device-mqtt.log
Wrote snap logs to /home/mengyi/Desktop/edgex400/edgex-snap-testing/test/suites/device-mqtt/edgex-device-mqtt.log
2023/04/24 11:39:35 [exec] (sudo journalctl --since "2023-04-24 11:35:09" --no-pager | grep "edgexfoundry"|| true) > edgexfoundry.log
Wrote snap logs to /home/mengyi/Desktop/edgex400/edgex-snap-testing/test/suites/device-mqtt/edgexfoundry.log
2023/04/24 11:39:35 Removing installed snap: true
2023/04/24 11:39:35 [exec] sudo snap remove --purge edgex-device-mqtt
2023/04/24 11:39:38 [stdout] edgex-device-mqtt removed
2023/04/24 11:39:38 [exec] sudo snap remove --purge edgexfoundry
2023/04/24 11:39:39 [stdout] 2023-04-24T11:39:39+02:00 INFO Waiting for "snap.edgexfoundry.core-data.service" to stop.
2023/04/24 11:39:40 [stdout] 2023-04-24T11:39:40+02:00 INFO Waiting for "snap.edgexfoundry.core-metadata.service" to stop.
2023/04/24 11:39:41 [stdout] 2023-04-24T11:39:41+02:00 INFO Waiting for "snap.edgexfoundry.support-scheduler.service" to stop.
2023/04/24 11:39:46 [stdout] edgexfoundry removed
ok      edgex-snap-testing/test/suites/device-mqtt      279.544s
```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->