### PR TITLE
feat!: Handle receiving multiple readings in the async payload

### DIFF
--- a/cmd/res/configuration.yaml
+++ b/cmd/res/configuration.yaml
@@ -14,15 +14,8 @@ Service:
   Host: "localhost"
   Port: 59982
   StartupMsg: "device mqtt started"
-# uncomment when running from command-line in hybrid mode with -cp -o flags
-# Clients:
-#   core-metadata:
-#     Host: "localhost"
-# Registry:
-#   Host: "localhost"
 
 MessageBus:
-  # Host: localhost # uncomment when running from command-line in hybrid mode
   Optional:
   # Default MQTT & NATS Specific options that need to be here to enable environment variable overrides of them
     ClientId: "device-mqtt"

--- a/cmd/res/profiles/mqtt.test.device.profile.yml
+++ b/cmd/res/profiles/mqtt.test.device.profile.yml
@@ -7,7 +7,7 @@ description: "Test device profile"
 deviceResources:
 -
   name: randfloat32
-  isHidden: true
+  isHidden: false
   description: "random 32 bit float"
   properties:
     valueType: "Float32"
@@ -17,7 +17,7 @@ deviceResources:
     maximum: 100
 -
   name: randfloat64
-  isHidden: true
+  isHidden: false
   description: "random 64 bit float"
   properties:
     valueType: "Float64"
@@ -27,7 +27,7 @@ deviceResources:
     maximum: 100
 -
   name: ping
-  isHidden: true
+  isHidden: false
   description: "device awake"
   properties:
     valueType: "String"
@@ -35,7 +35,7 @@ deviceResources:
     defaultValue: "oops"
 -
   name: message
-  isHidden: true
+  isHidden: false
   description: "device notification message"
   properties:
     valueType: "String"
@@ -50,32 +50,7 @@ deviceResources:
     mediaType: "application/json"
 
 deviceCommands:
--
-  name: testrandfloat32
-  readWrite: "R"
-  isHidden: false
-  resourceOperations:
-    - { deviceResource: "randfloat32" }
--
-  name: testrandfloat64
-  readWrite: "R"
-  isHidden: false
-  resourceOperations:
-    - { deviceResource: "randfloat64" }
--
-  name: testping
-  readWrite: "R"
-  isHidden: false
-  resourceOperations:
-    - { deviceResource: "ping" }
--
-  name: testmessage
-  readWrite: "RW"
-  isHidden: false
-  resourceOperations:
-    - { deviceResource: "message" }
--
-  name: allValues
+- name: allValues
   readWrite: "RW"
   isHidden: false
   resourceOperations:

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/edgexfoundry/device-sdk-go/v3/pkg/models"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,12 +26,12 @@ func init() {
 
 func TestNewResult_bool(t *testing.T) {
 	var reading interface{} = true
-	req := models.CommandRequest{
-		DeviceResourceName: "light",
-		Type:               common.ValueTypeBool,
+	resource := models.DeviceResource{
+		Name:       "light",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeBool},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -43,12 +43,12 @@ func TestNewResult_bool(t *testing.T) {
 
 func TestNewResult_uint8(t *testing.T) {
 	var reading interface{} = uint8(123)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeUint8,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeUint8},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -60,12 +60,12 @@ func TestNewResult_uint8(t *testing.T) {
 
 func TestNewResult_int8(t *testing.T) {
 	var reading interface{} = int8(123)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeInt8,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeInt8},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -77,12 +77,12 @@ func TestNewResult_int8(t *testing.T) {
 
 func TestNewResultFailed_int8(t *testing.T) {
 	var reading interface{} = int16(256)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeInt8,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeInt8},
 	}
 
-	_, err := newResult(req, reading)
+	_, err := newResult(resource, reading)
 	fmt.Println(err)
 	if err == nil || !strings.Contains(err.Error(), "Reading 256 is out of the value type(Int8)'s range") {
 		t.Errorf("Convert new result should be failed")
@@ -91,12 +91,12 @@ func TestNewResultFailed_int8(t *testing.T) {
 
 func TestNewResult_uint16(t *testing.T) {
 	var reading interface{} = uint16(123)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeUint16,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeUint16},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -108,12 +108,12 @@ func TestNewResult_uint16(t *testing.T) {
 
 func TestNewResult_int16(t *testing.T) {
 	var reading interface{} = int16(123)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeInt16,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeInt16},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -125,12 +125,12 @@ func TestNewResult_int16(t *testing.T) {
 
 func TestNewResult_uint32(t *testing.T) {
 	var reading interface{} = uint32(123)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeUint32,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeUint32},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -142,12 +142,12 @@ func TestNewResult_uint32(t *testing.T) {
 
 func TestNewResult_int32(t *testing.T) {
 	var reading interface{} = int32(123)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeInt32,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeInt32},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -159,12 +159,12 @@ func TestNewResult_int32(t *testing.T) {
 
 func TestNewResult_uint64(t *testing.T) {
 	var reading interface{} = uint64(123)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeUint64,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeUint64},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -176,12 +176,12 @@ func TestNewResult_uint64(t *testing.T) {
 
 func TestNewResult_int64(t *testing.T) {
 	var reading interface{} = int64(123)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeInt64,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeInt64},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -192,25 +192,25 @@ func TestNewResult_int64(t *testing.T) {
 }
 
 func TestNewResult_float32(t *testing.T) {
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeFloat32,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeFloat32},
 	}
 
 	tests := []struct {
 		name     string
-		req      models.CommandRequest
+		resource models.DeviceResource
 		reading  interface{}
 		expected interface{}
 	}{
-		{"Valid string 0", req, "0", float32(0)},
-		{"Valid string 123.32", req, "123.32", float32(123.32)},
-		{"Valid float32 0", req, 0, float32(0)},
-		{"Valid float32 123.32", req, 123.32, float32(123.32)},
+		{"Valid string 0", resource, "0", float32(0)},
+		{"Valid string 123.32", resource, "123.32", float32(123.32)},
+		{"Valid float32 0", resource, 0, float32(0)},
+		{"Valid float32 123.32", resource, 123.32, float32(123.32)},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			cmdVal, err := newResult(req, testCase.reading)
+			cmdVal, err := newResult(resource, testCase.reading)
 			require.NoError(t, err)
 			result, err := cmdVal.Float32Value()
 			require.NoError(t, err)
@@ -221,25 +221,25 @@ func TestNewResult_float32(t *testing.T) {
 }
 
 func TestNewResult_float64(t *testing.T) {
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeFloat64,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeFloat64},
 	}
 
 	tests := []struct {
 		name     string
-		req      models.CommandRequest
+		resource models.DeviceResource
 		reading  interface{}
 		expected interface{}
 	}{
-		{"Valid string 0", req, "0", float64(0)},
-		{"Valid string 0.123", req, "0.123", 0.123},
-		{"Valid float64 0", req, 0, float64(0)},
-		{"Valid float64 0.123", req, 0.123, 0.123},
+		{"Valid string 0", resource, "0", float64(0)},
+		{"Valid string 0.123", resource, "0.123", 0.123},
+		{"Valid float64 0", resource, 0, float64(0)},
+		{"Valid float64 0.123", resource, 0.123, 0.123},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			cmdVal, err := newResult(req, testCase.reading)
+			cmdVal, err := newResult(resource, testCase.reading)
 			require.NoError(t, err)
 			result, err := cmdVal.Float64Value()
 			require.NoError(t, err)
@@ -250,13 +250,13 @@ func TestNewResult_float64(t *testing.T) {
 }
 
 func TestNewResult_float64ToInt8(t *testing.T) {
-	var reading interface{} = float64(123.11)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeInt8,
+	var reading interface{} = 123.11
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeInt8},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -267,13 +267,13 @@ func TestNewResult_float64ToInt8(t *testing.T) {
 }
 
 func TestNewResult_float64ToInt16(t *testing.T) {
-	var reading interface{} = float64(123.11)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeInt16,
+	var reading interface{} = 123.11
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeInt16},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -284,13 +284,13 @@ func TestNewResult_float64ToInt16(t *testing.T) {
 }
 
 func TestNewResult_float64ToInt32(t *testing.T) {
-	var reading interface{} = float64(123.11)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeInt32,
+	var reading interface{} = 123.11
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeInt32},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -301,13 +301,13 @@ func TestNewResult_float64ToInt32(t *testing.T) {
 }
 
 func TestNewResult_float64ToInt64(t *testing.T) {
-	var reading interface{} = float64(123.11)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeInt64,
+	var reading interface{} = 123.11
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeInt64},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -318,13 +318,13 @@ func TestNewResult_float64ToInt64(t *testing.T) {
 }
 
 func TestNewResult_float64ToUint8(t *testing.T) {
-	var reading interface{} = float64(123.11)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeUint8,
+	var reading interface{} = 123.11
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeUint8},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -335,13 +335,13 @@ func TestNewResult_float64ToUint8(t *testing.T) {
 }
 
 func TestNewResult_float64ToUint16(t *testing.T) {
-	var reading interface{} = float64(123.11)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeUint16,
+	var reading interface{} = 123.11
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeUint16},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -352,13 +352,13 @@ func TestNewResult_float64ToUint16(t *testing.T) {
 }
 
 func TestNewResult_float64ToUint32(t *testing.T) {
-	var reading interface{} = float64(123.11)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeUint32,
+	var reading interface{} = 123.11
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeUint32},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -369,13 +369,13 @@ func TestNewResult_float64ToUint32(t *testing.T) {
 }
 
 func TestNewResult_float64ToUint64(t *testing.T) {
-	var reading interface{} = float64(123.11)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeUint64,
+	var reading interface{} = 123.11
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeUint64},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -386,13 +386,13 @@ func TestNewResult_float64ToUint64(t *testing.T) {
 }
 
 func TestNewResult_float64ToFloat32(t *testing.T) {
-	var reading interface{} = float64(123.11)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeFloat32,
+	var reading interface{} = 123.11
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeFloat32},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -403,13 +403,13 @@ func TestNewResult_float64ToFloat32(t *testing.T) {
 }
 
 func TestNewResult_float64ToString(t *testing.T) {
-	var reading interface{} = float64(123.11)
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeString,
+	var reading interface{} = 123.11
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeString},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -421,12 +421,12 @@ func TestNewResult_float64ToString(t *testing.T) {
 
 func TestNewResult_string(t *testing.T) {
 	var reading interface{} = "test string"
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeString,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeString},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -438,12 +438,12 @@ func TestNewResult_string(t *testing.T) {
 
 func TestNewResult_stringToInt64(t *testing.T) {
 	var reading interface{} = "123"
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeInt64,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeInt64},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -455,12 +455,12 @@ func TestNewResult_stringToInt64(t *testing.T) {
 
 func TestNewResult_stringToInt8(t *testing.T) {
 	var reading interface{} = "123"
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeInt8,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeInt8},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -472,12 +472,12 @@ func TestNewResult_stringToInt8(t *testing.T) {
 
 func TestNewResult_stringToUint8(t *testing.T) {
 	var reading interface{} = "123"
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeUint8,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeUint8},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -489,12 +489,12 @@ func TestNewResult_stringToUint8(t *testing.T) {
 
 func TestNewResult_stringToUint32(t *testing.T) {
 	var reading interface{} = "123"
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeUint32,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeUint32},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -506,12 +506,12 @@ func TestNewResult_stringToUint32(t *testing.T) {
 
 func TestNewResult_stringToUint64(t *testing.T) {
 	var reading interface{} = "123"
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeUint64,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeUint64},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -523,12 +523,12 @@ func TestNewResult_stringToUint64(t *testing.T) {
 
 func TestNewResult_stringToBool(t *testing.T) {
 	var reading interface{} = "true"
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeBool,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeBool},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -540,12 +540,12 @@ func TestNewResult_stringToBool(t *testing.T) {
 
 func TestNewResult_numberToUint64(t *testing.T) {
 	var reading interface{} = 123
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeUint64,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeUint64},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -557,12 +557,12 @@ func TestNewResult_numberToUint64(t *testing.T) {
 
 func TestNewResult_floatNumberToFloat32(t *testing.T) {
 	var reading interface{} = 123.0
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeFloat32,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeFloat32},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -574,12 +574,12 @@ func TestNewResult_floatNumberToFloat32(t *testing.T) {
 
 func TestNewResult_numberToString(t *testing.T) {
 	var reading interface{} = 123
-	req := models.CommandRequest{
-		DeviceResourceName: "temperature",
-		Type:               common.ValueTypeString,
+	resource := models.DeviceResource{
+		Name:       "temperature",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeString},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	if err != nil {
 		t.Fatalf("Fail to create new ReadCommand result, %v", err)
 	}
@@ -590,13 +590,13 @@ func TestNewResult_numberToString(t *testing.T) {
 }
 
 func TestNewResult_object(t *testing.T) {
-	var reading interface{} = map[string]string{name: "My JSON"}
-	req := models.CommandRequest{
-		DeviceResourceName: "json",
-		Type:               common.ValueTypeObject,
+	var reading interface{} = map[string]string{"json": "My JSON"}
+	resource := models.DeviceResource{
+		Name:       "json",
+		Properties: models.ResourceProperties{ValueType: common.ValueTypeObject},
 	}
 
-	cmdVal, err := newResult(req, reading)
+	cmdVal, err := newResult(resource, reading)
 	require.NoError(t, err)
 	val, err := cmdVal.ObjectValue()
 	require.NoError(t, err)

--- a/internal/driver/incominglistener.go
+++ b/internal/driver/incominglistener.go
@@ -7,55 +7,92 @@
 package driver
 
 import (
+	"encoding/json"
 	"strings"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
-	"github.com/edgexfoundry/device-sdk-go/v3/pkg/models"
+	sdkModels "github.com/edgexfoundry/device-sdk-go/v3/pkg/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 )
 
-const (
-	name = "name"
-	cmd  = "cmd"
-)
-
-func (d *Driver) onIncomingDataReceived(client mqtt.Client, message mqtt.Message) {
+func (d *Driver) onIncomingDataReceived(_ mqtt.Client, message mqtt.Message) {
 	var deviceName string
-	var resourceName string
-	var reading interface{}
+	var sourceName string
 
+	var deviceResources []models.DeviceResource
 	incomingTopic := message.Topic()
 	subscribedTopic := d.serviceConfig.MQTTBrokerInfo.IncomingTopic
 	subscribedTopic = strings.Replace(subscribedTopic, "#", "", -1)
 	incomingTopic = strings.Replace(incomingTopic, subscribedTopic, "", -1)
 	metaData := strings.Split(incomingTopic, "/")
 	if len(metaData) != 2 {
-		driver.Logger.Errorf("[Incoming listener] Incoming reading ignored, incoming topic data should have format .../<device_name>/<resource_name>: `%s`", incomingTopic)
+		driver.Logger.Errorf("[Incoming listener] Incoming data ignored, incoming topic data should have format .../<device_name>/<source_name>: `%s`", incomingTopic)
 		return
 	}
 	deviceName = metaData[0]
-	resourceName = metaData[1]
-	reading = string(message.Payload())
+	sourceName = metaData[1]
 
-	deviceObject, ok := d.sdk.DeviceResource(deviceName, resourceName)
+	deviceCommand, ok := d.sdk.DeviceCommand(deviceName, sourceName)
 	if !ok {
-		driver.Logger.Errorf("[Incoming listener] Incoming reading ignored, device resource `%s` not found from the device `%s`", resourceName, deviceName)
-		return
+		deviceResource, ok := d.sdk.DeviceResource(deviceName, sourceName)
+		if !ok {
+			driver.Logger.Errorf("[Incoming listener] Incoming data ignored, source name `%s` not found as Device Command or Device Resource on the device `%s`", sourceName, deviceName)
+			return
+		}
+
+		if !strings.Contains(strings.ToUpper(deviceResource.Properties.ReadWrite), "R") {
+			driver.Logger.Errorf("[Incoming listener] Incoming data ignored, Device Resource `%s` not Readable", sourceName)
+			return
+		}
+
+		deviceResources = append(deviceResources, deviceResource)
+	} else {
+		if !strings.Contains(strings.ToUpper(deviceCommand.ReadWrite), "R") {
+			driver.Logger.Errorf("[Incoming listener] Incoming data ignored, Device Command `%s` not Readable", sourceName)
+			return
+		}
+
+		for _, resourceOperation := range deviceCommand.ResourceOperations {
+			deviceResource, ok := d.sdk.DeviceResource(deviceName, resourceOperation.DeviceResource)
+			if !ok {
+				driver.Logger.Errorf("[Incoming listener] Incoming data ignored, resource name `%s` from Device Command %s not found on the device `%s`", resourceOperation.DeviceResource, sourceName, deviceName)
+				return
+			}
+
+			deviceResources = append(deviceResources, deviceResource)
+		}
 	}
 
-	req := models.CommandRequest{
-		DeviceResourceName: resourceName,
-		Type:               deviceObject.Properties.ValueType,
-	}
-
-	result, err := newResult(req, reading)
+	var asyncData map[string]interface{}
+	err := json.Unmarshal(message.Payload(), &asyncData)
 	if err != nil {
-		driver.Logger.Errorf("[Incoming listener] Incoming reading ignored, %v", err)
+		driver.Logger.Errorf("[Incoming listener] Error un-marshaling incoming data : %v", err)
 		return
 	}
 
-	asyncValues := &models.AsyncValues{
+	var commandValues []*sdkModels.CommandValue
+
+	for _, resource := range deviceResources {
+		asyncValue, ok := asyncData[resource.Name]
+		if !ok {
+			driver.Logger.Errorf("[Incoming listener] Incoming data ignored: Resource Name %s not found in payload (%s)", resource.Name, string(message.Payload()))
+			return
+		}
+
+		commandValue, err := newResult(resource, asyncValue)
+		if err != nil {
+			driver.Logger.Errorf("[Incoming listener] Incoming data ignored: %v", err)
+			return
+		}
+
+		commandValues = append(commandValues, commandValue)
+
+	}
+
+	asyncValues := &sdkModels.AsyncValues{
 		DeviceName:    deviceName,
-		CommandValues: []*models.CommandValue{result},
+		SourceName:    sourceName,
+		CommandValues: commandValues,
 	}
 
 	driver.Logger.Debugf("[Incoming listener] Incoming reading received: topic=%v msg=%v", message.Topic(), string(message.Payload()))


### PR DESCRIPTION
BREAKING CHANGE: The published async payload must now be json containing the resource names and values, even when a single resource is sent. Redendent single resource Device Commands (`testrandfloat32`, `testrandfloat64`, `testping` and `testmessage`) in `mqtt.test.device.profile.yml` have be removed. Use the corrisponding resource name (`randfloat32`, `randfloat64`, `ping` or `message`) instead.


closes https://github.com/edgexfoundry/device-mqtt-go/issues/299

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
https://github.com/edgexfoundry/edgex-docs/pull/1046

## Testing Instructions
Run the updated example from this PR: https://github.com/edgexfoundry/edgex-docs/pull/1046
Verify the async event now have three readings

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->