### PR TITLE
fix: [WIP BUG] Add back ability for async payload to just be value when for single resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.4.2
-	github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.90
-	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.88
+	github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.92
+	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.90
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.41
 	github.com/google/uuid v1.3.0
 	github.com/spf13/cast v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -27,10 +27,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.90 h1:LaoB9SDmev2kXzyhTHjnr2TOaFrU5Cp1rhGVh/7mybE=
-github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.90/go.mod h1:2hX4JOa5EpWOrrsLJ86KUTF1f+cxOZtrhNvJ1sNwkdg=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.88 h1:5XlK5l4JvNfVHhFBlDPfeIFPubG6uC3IRhXCMBb/Fig=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.88/go.mod h1:/l9+zh+pthpA/wv/Y4ZROWfNLk5R3G27t/2yJHO2s/g=
+github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.92 h1:JUR8fO3UHsKkrC8r9FOyK/IXx0N7RnW7RYnBzCBPIvA=
+github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.92/go.mod h1:ghxEYCX1ld0x4k+dINrozDpx0hwQLz5ddCzl825NgR8=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.90 h1:fd/Y1DrgobWkvLbsbOyU5pQjvmpn9o5VEM6bbd8yP48=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.90/go.mod h1:/l9+zh+pthpA/wv/Y4ZROWfNLk5R3G27t/2yJHO2s/g=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.10 h1:iDuAO3vpBQnlQuFhai/NATbJkiYXxo3bPCtSnFl07Yw=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.10/go.mod h1:8RlYm5CPzZgUsfXDWVP1TIeUMhsDNIdRdj1HXdomtOI=
 github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.41 h1:ZFrxABViVju6AAOkM8iergHTjLdqdycv9iOnKJV7r4s=


### PR DESCRIPTION
fixes #603

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
run non-secure edgex with mqtt-broker
Use mqtt.FX to publish following data
- `1.06` to incoming/data/MQTT-test-device/randfloat32
- `6.78` to incoming/data/MQTT-test-device/randfloat64
- `pong` to incoming/data/MQTT-test-device/ping
- `Hi World` to incoming/data/MQTT-test-device/message
- `{}` to incoming/data/MQTT-test-device/json
- `{"randfloat32":0.8, "randfloat64": 1.2, "message": "hi" }` to incoming/data/MQTT-test-device/allValues
- `{"randfloat32":0.8}` to incoming/data/MQTT-test-device/randfloat32
Verify all are successfully process and appropriate Event/Readings are create and published.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->